### PR TITLE
온보딩 3/3 푸시알림 권한 받기

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".Smeem"

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
@@ -1,9 +1,13 @@
 package com.sopt.smeem.presentation.onboarding
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import androidx.core.content.ContextCompat
 import com.sopt.smeem.R
 import com.sopt.smeem.TrainingGoalType
 import com.sopt.smeem.databinding.ActivityOnBoardingBinding
@@ -103,8 +107,8 @@ class OnBoardingActivity :
                 }
 
                 4 -> { // step 4 : 알림 권한 체크 및 api token 가 local 에 있는지 (이전에 로그인했는지 check)
-                    checkPushPermission()
-                    checkAlreadyAuthed() // 3/3 (트레이닝 시간 설정) 에서 로그인 바텀시트 띄우기전에 이미 kakao 로그인이 된 상태인지 확인
+                    checkNotiPermission()
+//                    checkAlreadyAuthed() // 3/3 (트레이닝 시간 설정) 에서 로그인 바텀시트 띄우기전에 이미 kakao 로그인이 된 상태인지 확인
                 }
 
                 else -> {}
@@ -208,22 +212,69 @@ class OnBoardingActivity :
         finish()
     }
 
-    private fun checkPushPermission() {
-        // TODO : push 권한 체크
-        MaterialAlertDialogBuilder(this)
-            .setIcon(R.drawable.ic_notification_dialog)
-            .setTitle(
-                "‘smeem’에서 알림을\n" +
-                        "보내도록 허용하시겠습니까?"
-            )
-            .setNegativeButton("예") { dialog, which ->
-                // TODO: hasAlarm 관련 livedata = true
+    private fun checkNotiPermission() {
+        when {
+            // 1. 알림 권한이 이미 허용되었을 때
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                Log.d("checkNotiPermission - granted", "Notification Permission Granted")
+                checkAlreadyAuthed()
             }
-            .setPositiveButton("아니요") { dialog, which ->
-                // TODO: hasAlarm 관련 livedata = false
+            // 2. 사용자가 이전에 권한을 거부했을 때
+            // 앱을 사용할 때 권한이 필요하다고 사용자에게 알려줘야 함
+            // TODO: 넣을까 말까
+            shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                Log.d("checkNotiPermission - denied once", "Notification Permission Denied Once")
+                notiPermissionResultCallback.launch(
+                    Manifest.permission.POST_NOTIFICATIONS
+                )
             }
-            .show()
+            // 3. 알림 권한을 처음으로 받는 것일 때
+            else -> {
+                Log.d("checkNotiPermission - initial", "First Attempt to Get Notification Permission")
+                notiPermissionResultCallback.launch(
+                    Manifest.permission.POST_NOTIFICATIONS
+                )
+            }
+        }
     }
+
+    private val notiPermissionResultCallback =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { isGranted: Boolean ->
+            if (!isGranted) {
+                Log.d("callback - denied", "Notification Permission Denied")
+                // TODO: hasAlarm 관련 livedata = false
+                checkAlreadyAuthed()
+            } else {
+                Log.d("callback - granted", "Notification Permission Granted")
+                // TODO: hasAlarm 관련 livedata = true
+                checkAlreadyAuthed()
+            }
+        }
+
+//    private fun showNotiPermissonDialog() {
+//        Log.d("Is this function invoked??", "Yes!")
+//
+//        MaterialAlertDialogBuilder(this)
+//            .setIcon(R.drawable.ic_notification_dialog)
+//            .setTitle(
+//                "‘smeem’에서 알림을\n" +
+//                        "보내도록 허용하시겠습니까?"
+//            )
+//            .setNegativeButton("예") { dialog, which ->
+//                // TODO: hasAlarm 관련 livedata = true
+//                checkAlreadyAuthed()
+//            }
+//            .setPositiveButton("아니요") { dialog, which ->
+//                // TODO: hasAlarm 관련 livedata = false
+//                checkAlreadyAuthed()
+//            }
+//            .show()
+//    }
 
     private fun checkAlreadyAuthed() {
         if (vm.alreadyAuthed()) {

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
@@ -218,11 +218,13 @@ class OnBoardingActivity :
                 this,
                 Manifest.permission.POST_NOTIFICATIONS
             ) == PackageManager.PERMISSION_GRANTED -> {
+                vm.setNotiPermissionStatus(true)
                 // 3/3 (트레이닝 시간 설정) 에서 로그인 바텀시트 띄우기전에 이미 kakao 로그인이 된 상태인지 확인
                 checkAlreadyAuthed()
             }
             // 2. 사용자가 이전에 권한을 거부했을 때
             shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                vm.setNotiPermissionStatus(false)
                 checkAlreadyAuthed()
             }
             // 3. 알림 권한을 처음으로 받는 것일 때
@@ -239,12 +241,14 @@ class OnBoardingActivity :
             ActivityResultContracts.RequestPermission()
         ) { isGranted: Boolean ->
             if (!isGranted) {
-                Log.d("callback - denied", "Notification Permission Denied")
-                // TODO: hasAlarm 관련 livedata = false
-                checkAlreadyAuthed()
+                vm.setNotiPermissionStatus(false)
+                // dialog 바깥쪽을 눌러 나간 경우 (허용, 거부 선택하지 않은 경우)
+                // 바텀시트가 뜨지 않도록
+                if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                    checkAlreadyAuthed()
+                }
             } else {
-                Log.d("callback - granted", "Notification Permission Granted")
-                // TODO: hasAlarm 관련 livedata = true
+                vm.setNotiPermissionStatus(true)
                 checkAlreadyAuthed()
             }
         }

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
@@ -108,7 +108,6 @@ class OnBoardingActivity :
 
                 4 -> { // step 4 : 알림 권한 체크 및 api token 가 local 에 있는지 (이전에 로그인했는지 check)
                     checkNotiPermission()
-//                    checkAlreadyAuthed() // 3/3 (트레이닝 시간 설정) 에서 로그인 바텀시트 띄우기전에 이미 kakao 로그인이 된 상태인지 확인
                 }
 
                 else -> {}
@@ -219,21 +218,15 @@ class OnBoardingActivity :
                 this,
                 Manifest.permission.POST_NOTIFICATIONS
             ) == PackageManager.PERMISSION_GRANTED -> {
-                Log.d("checkNotiPermission - granted", "Notification Permission Granted")
+                // 3/3 (트레이닝 시간 설정) 에서 로그인 바텀시트 띄우기전에 이미 kakao 로그인이 된 상태인지 확인
                 checkAlreadyAuthed()
             }
             // 2. 사용자가 이전에 권한을 거부했을 때
-            // 앱을 사용할 때 권한이 필요하다고 사용자에게 알려줘야 함
-            // TODO: 넣을까 말까
             shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
-                Log.d("checkNotiPermission - denied once", "Notification Permission Denied Once")
-                notiPermissionResultCallback.launch(
-                    Manifest.permission.POST_NOTIFICATIONS
-                )
+                checkAlreadyAuthed()
             }
             // 3. 알림 권한을 처음으로 받는 것일 때
             else -> {
-                Log.d("checkNotiPermission - initial", "First Attempt to Get Notification Permission")
                 notiPermissionResultCallback.launch(
                     Manifest.permission.POST_NOTIFICATIONS
                 )
@@ -255,26 +248,6 @@ class OnBoardingActivity :
                 checkAlreadyAuthed()
             }
         }
-
-//    private fun showNotiPermissonDialog() {
-//        Log.d("Is this function invoked??", "Yes!")
-//
-//        MaterialAlertDialogBuilder(this)
-//            .setIcon(R.drawable.ic_notification_dialog)
-//            .setTitle(
-//                "‘smeem’에서 알림을\n" +
-//                        "보내도록 허용하시겠습니까?"
-//            )
-//            .setNegativeButton("예") { dialog, which ->
-//                // TODO: hasAlarm 관련 livedata = true
-//                checkAlreadyAuthed()
-//            }
-//            .setPositiveButton("아니요") { dialog, which ->
-//                // TODO: hasAlarm 관련 livedata = false
-//                checkAlreadyAuthed()
-//            }
-//            .show()
-//    }
 
     private fun checkAlreadyAuthed() {
         if (vm.alreadyAuthed()) {

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
@@ -1,5 +1,6 @@
 package com.sopt.smeem.presentation.onboarding
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -49,6 +50,10 @@ class OnBoardingVM @Inject constructor(
     private val _setTimeLater = MutableLiveData<Boolean>()
     val setTimeLater: LiveData<Boolean>
         get() = _setTimeLater
+
+    private val _isNotiGranted = MutableLiveData<Boolean>()
+    val isNotiGranted: LiveData<Boolean>
+        get() = _isNotiGranted
 
     private val _goAnonymous = MutableLiveData<Boolean>()
     val goAnonymous: LiveData<Boolean>
@@ -120,6 +125,11 @@ class OnBoardingVM @Inject constructor(
 
     fun timeLater() {
         _setTimeLater.value = true
+        setNotiPermissionStatus(false)
+    }
+
+    fun setNotiPermissionStatus(status: Boolean) {
+        _isNotiGranted.value = status
     }
 
     fun login(
@@ -158,8 +168,7 @@ class OnBoardingVM @Inject constructor(
             userRepositoryWithAnonymous.registerOnBoarding(
                 OnBoarding(
                     trainingGoalType = selectedGoal.value ?: TrainingGoalType.NO_SELECTED,
-                    // TODO: 알림 권한에 동의했을 때는?
-                    hasAlarm = setTimeLater.value?.not() ?: false,
+                    hasAlarm = isNotiGranted.value ?: false,
                     day = days,
                     hour = hour,
                     minute = minute
@@ -177,7 +186,7 @@ class OnBoardingVM @Inject constructor(
                 Training(
                     type = selectedGoal.value ?: TrainingGoalType.NO_SELECTED,
                     trainingTime = TrainingTime(days = days.toSet(), hour = hour, minute = minute),
-                    hasAlarm = setTimeLater.value?.not() ?: false
+                    hasAlarm = isNotiGranted.value ?: false,
                 )
             )
                 .onSuccess(onSuccess)


### PR DESCRIPTION
## *Related issue*
* close #72 

## *Description*
* 시스템 dialog를 통해 푸시알림 권한 받는 기능 구현
* 현재 정책
    * Android 13 이상 (api 33 ⬆️)
        * 3/3에서 완료 버튼 클릭 시 권한 묻는 dialog 띄우기
        * 허용/거부 선택했을 때만 hasAlarm 값 설정 -> 로그인 바텀시트 띄우기
        * 허용/거부 선택할시 dialog 다시 띄우지 않음 (아요와 동일)
        * 어느 것도 선택하지 않고 dialog를 내렸을 때 -> 완료 버튼 클릭시 다시 띄움  
    * Android 12 이하
        * default가 허용이므로 dialog 띄우지 않고 바로 로그인 바텀시트 띄우기
        * '나중에 설정할래요' 클릭 시 hasAlarm false로 설정
            * 서버측에서 알림 보내주지 않음 

## *PR point*
* 모든 분기마다 `checkAlreadyAuthed()`를 부르게 되는 것 같은데 더 좋은 방법이 있으면 의견 주시면 정말 감사하겠습니다!
* 시스템 상에서 띄워주는 dialog은 디자인 커스텀이 되지 않더라고요... 디쟌쌤들이랑 논의해보겠습니다
    * https://developer.android.com/training/permissions/requesting 
<img width="742" alt="image" src="https://github.com/Team-Smeme/smeem-aos/assets/74162198/de519fea-35e3-4c27-bdee-d34c737ff373">

## *Screenshot*
<img src="https://github.com/Team-Smeme/smeem-aos/assets/74162198/263f2e18-ec07-4dee-8d11-2b035edbdd41" width="360"/>
