### PR TITLE
Naming 변경 PR

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
 
         <!-- Splash -->
         <activity
-            android:name=".presentation.splash.SplashActivity"
+            android:name=".presentation.splash.SplashLoginActivity"
             android:exported="true">
 
             <intent-filter>

--- a/app/src/main/java/com/sopt/smeem/data/repository/LocalRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/data/repository/LocalRepositoryImpl.kt
@@ -7,16 +7,16 @@ import com.sopt.smeem.SmeemErrorCode
 import com.sopt.smeem.SmeemException
 import com.sopt.smeem.data.SmeemDataStore.dataStore
 import com.sopt.smeem.domain.model.Authentication
-import com.sopt.smeem.domain.repository.AuthRepository
+import com.sopt.smeem.domain.repository.LocalRepository
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
 
-class AuthRepositoryImpl @Inject constructor(
+class LocalRepositoryImpl @Inject constructor(
     private val context: Context
-) : AuthRepository {
+) : LocalRepository {
 
     /**
      * LocalStorage 로 부터 Authentication 추출

--- a/app/src/main/java/com/sopt/smeem/domain/repository/LocalRepository.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/repository/LocalRepository.kt
@@ -2,7 +2,7 @@ package com.sopt.smeem.domain.repository
 
 import com.sopt.smeem.domain.model.Authentication
 
-interface AuthRepository {
+interface LocalRepository {
     suspend fun getAuthentication(): Authentication?
     suspend fun setAuthentication(authentication: Authentication): Unit
     suspend fun isAuthenticated(): Boolean

--- a/app/src/main/java/com/sopt/smeem/module/AuthModule.kt
+++ b/app/src/main/java/com/sopt/smeem/module/AuthModule.kt
@@ -1,8 +1,8 @@
 package com.sopt.smeem.module
 
 import android.content.Context
-import com.sopt.smeem.data.repository.AuthRepositoryImpl
-import com.sopt.smeem.domain.repository.AuthRepository
+import com.sopt.smeem.data.repository.LocalRepositoryImpl
+import com.sopt.smeem.domain.repository.LocalRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +17,5 @@ object AuthModule {
     @Singleton
     fun authRepository(
         @ApplicationContext context: Context
-    ): AuthRepository = AuthRepositoryImpl(context)
+    ): LocalRepository = LocalRepositoryImpl(context)
 }

--- a/app/src/main/java/com/sopt/smeem/module/NetworkModule.kt
+++ b/app/src/main/java/com/sopt/smeem/module/NetworkModule.kt
@@ -1,7 +1,7 @@
 package com.sopt.smeem.module
 
 import com.sopt.smeem.BuildConfig.API_SERVER_URL
-import com.sopt.smeem.domain.repository.AuthRepository
+import com.sopt.smeem.domain.repository.LocalRepository
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @Module
 @InstallIn(SingletonComponent::class)
 class NetworkModule @Inject constructor(
-    private val authRepository: AuthRepository,
+    private val localRepository: LocalRepository,
 ) {
     val apiServerRetrofitForAnonymous by lazy {
         Retrofit.Builder()
@@ -50,11 +50,11 @@ class NetworkModule @Inject constructor(
                     readTimeout(5, TimeUnit.SECONDS)
 
                     runBlocking { // TODO : 제거
-                        if (authRepository.isAuthenticated()) {
+                        if (localRepository.isAuthenticated()) {
                             addInterceptor(
                                 RequestInterceptor(
-                                    accessToken = authRepository.getAuthentication()!!.accessToken!!,
-                                    refreshToken = authRepository.getAuthentication()!!.refreshToken,
+                                    accessToken = localRepository.getAuthentication()!!.accessToken!!,
+                                    refreshToken = localRepository.getAuthentication()!!.refreshToken,
                                 ),
                             )
                         }

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
@@ -1,6 +1,5 @@
 package com.sopt.smeem.presentation.onboarding
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -17,7 +16,7 @@ import com.sopt.smeem.domain.model.OnBoarding
 import com.sopt.smeem.domain.model.Training
 import com.sopt.smeem.domain.model.TrainingGoal
 import com.sopt.smeem.domain.model.TrainingTime
-import com.sopt.smeem.domain.repository.AuthRepository
+import com.sopt.smeem.domain.repository.LocalRepository
 import com.sopt.smeem.domain.repository.LoginRepository
 import com.sopt.smeem.domain.repository.TrainingRepository
 import com.sopt.smeem.domain.repository.UserRepository
@@ -32,7 +31,7 @@ class OnBoardingVM @Inject constructor(
     @Anonymous private val trainingRepository: TrainingRepository,
     @Anonymous private val userRepositoryWithAnonymous: UserRepository,
     private val userRepositoryWithAuth: UserRepository,
-    private val authRepository: AuthRepository,
+    private val localRepository: LocalRepository,
 ) : ViewModel() {
 
     private val _loginResult = MutableLiveData<LoginResult>()
@@ -86,7 +85,7 @@ class OnBoardingVM @Inject constructor(
 
     }
 
-    fun alreadyAuthed() = viewModelScope.async { authRepository.isAuthenticated() }.getCompleted()
+    fun alreadyAuthed() = viewModelScope.async { localRepository.isAuthenticated() }.getCompleted()
 
     fun isDaySelected(content: String) = days.contains(Day.from(content))
     fun addDay(content: String) = days.add(Day.from(content))
@@ -142,7 +141,7 @@ class OnBoardingVM @Inject constructor(
             loginRepository.execute(accessToken = kakaoAccessToken, socialType)
                 .onSuccess {
                     // save on local storage
-                    authRepository.setAuthentication(
+                    localRepository.setAuthentication(
                         Authentication(
                             accessToken = it.apiAccessToken,
                             refreshToken = it.apiRefreshToken

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/LoginVM.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/LoginVM.kt
@@ -10,7 +10,7 @@ import com.sopt.smeem.SocialType
 import com.sopt.smeem.data.ApiPool.onHttpFailure
 import com.sopt.smeem.domain.model.Authentication
 import com.sopt.smeem.domain.model.LoginResult
-import com.sopt.smeem.domain.repository.AuthRepository
+import com.sopt.smeem.domain.repository.LocalRepository
 import com.sopt.smeem.domain.repository.LoginRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class LoginVM @Inject constructor(
-    private val authRepository: AuthRepository,
+    private val localRepository: LocalRepository,
     @Anonymous private val loginRepository: LoginRepository
 ) : ViewModel() {
     private val _loginResult = MutableLiveData<LoginResult>()
@@ -34,7 +34,7 @@ internal class LoginVM @Inject constructor(
         viewModelScope.launch {
             loginRepository.execute(kakaoAccessToken, socialType)
                 .onSuccess {
-                    authRepository.setAuthentication( // save on local storage
+                    localRepository.setAuthentication( // save on local storage
                         Authentication(
                             accessToken = it.apiAccessToken,
                             refreshToken = it.apiRefreshToken
@@ -48,6 +48,6 @@ internal class LoginVM @Inject constructor(
     }
 
     fun isAuthed(): Boolean {
-        return runBlocking { authRepository.isAuthenticated() }
+        return runBlocking { localRepository.isAuthenticated() }
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/SplashLoginActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/SplashLoginActivity.kt
@@ -3,7 +3,7 @@ package com.sopt.smeem.presentation.splash
 import android.content.Intent
 import androidx.activity.viewModels
 import com.sopt.smeem.R
-import com.sopt.smeem.databinding.ActivitySplashBinding
+import com.sopt.smeem.databinding.ActivitySplashLoginBinding
 import com.sopt.smeem.domain.model.LoginResult
 import com.sopt.smeem.presentation.BindingActivity
 import com.sopt.smeem.presentation.home.HomeActivity
@@ -13,7 +13,8 @@ import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
+class SplashLoginActivity :
+    BindingActivity<ActivitySplashLoginBinding>(R.layout.activity_splash_login) {
     lateinit var bs: LoginBottomSheet
     private val vm: LoginVM by viewModels()
 
@@ -43,12 +44,13 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     }
 
     private fun onAutoAuthed() {
-        when(vm.isAuthed()) {
+        when (vm.isAuthed()) {
             true -> {
                 // TODO : isRegistered, hasPlan 값들도 DataStore 에 저장해 온보딩중 이탈 회원 자동으로 이동하도록 (QA fix)
-                startActivity(Intent(this@SplashActivity, HomeActivity::class.java))
+                startActivity(Intent(this@SplashLoginActivity, HomeActivity::class.java))
                 finish()
             }
+
             false -> {
                 // do nothing
             }
@@ -62,7 +64,7 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     }
 
     private fun afterLoginSuccess() {
-        vm.loginResult.observe(this@SplashActivity) {
+        vm.loginResult.observe(this@SplashLoginActivity) {
             when (it.isRegistered) {
                 true -> gotoHome() // 회원 정보 등록까지 완료된 상태라면, Home 으로 이동
                 false -> gotoNext(it) // 회원 정보 등록이 되지 않은 상태 (학습 목표, 닉네임 세팅이 되어있는지에 따라 분기)
@@ -83,12 +85,12 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     }
 
     private fun gotoJoin() {
-        startActivity(Intent(this@SplashActivity, JoinWithNicknameActivity::class.java))
+        startActivity(Intent(this@SplashLoginActivity, JoinWithNicknameActivity::class.java))
         if (!isFinishing) finish()
     }
 
     private fun gotoOnBoarding() {
-        startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
+        startActivity(Intent(this@SplashLoginActivity, OnBoardingActivity::class.java))
         if (!isFinishing) finish()
     }
 }

--- a/app/src/main/res/layout/activity_splash_login.xml
+++ b/app/src/main/res/layout/activity_splash_login.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="signIn"
-            type="com.sopt.smeem.presentation.splash.SplashActivity" />
+            type="com.sopt.smeem.presentation.splash.SplashLoginActivity" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
- Splash 가 추가됨에 따라 기존 SplashActivity 를 분리합니다.
  - SplashStartActivity
  - SplashLoginActivity
- AuthRepository -> LocalRepository
  - DataStore 의 값은 Auth 외의 값을 저장하고 한 Repository 로 매니징되게 네이밍 변경합니다. 