### PR TITLE
온보딩 뒤로가기 로직 수정

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
@@ -100,6 +100,8 @@ class OnBoardingActivity :
                     setHeaderDescription(resources.getText(R.string.on_boarding_encouraging_header_description))
                     setButtonTextNext()
 
+                    vm.isDaysEmpty.value = false
+
                     supportFragmentManager.beginTransaction()
                         .replace(
                             R.id.fcv_on_boarding,

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingActivity.kt
@@ -16,6 +16,7 @@ import com.sopt.smeem.presentation.home.HomeActivity
 import com.sopt.smeem.presentation.join.JoinConstant.ACCESS_TOKEN
 import com.sopt.smeem.presentation.join.JoinConstant.REFRESH_TOKEN
 import com.sopt.smeem.presentation.join.JoinWithNicknameActivity
+import com.sopt.smeem.presentation.splash.SplashLoginActivity
 import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -73,6 +74,13 @@ class OnBoardingActivity :
     private fun observeStepChanging() {
         vm.step.observe(this@OnBoardingActivity) { step ->
             when (step) {
+                0 -> {
+                    Intent(this, SplashLoginActivity::class.java).run {
+                        startActivity(this)
+                        finish()
+                    }
+                }
+
                 1 -> { // step 1 fragment => 학습 목표 선택하기
                     setHeaderStepNo(1)
                     setHeaderTitle(resources.getText(R.string.on_boarding_goal_header_title))

--- a/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/onboarding/OnBoardingVM.kt
@@ -83,10 +83,14 @@ class OnBoardingVM @Inject constructor(
 
     fun backStep() {
         _step.value =
-            step.value?.minus(1)?.let { backedStep ->
-                if (backedStep < 1) 1 else backedStep // 1 보다 작을 수 없다.
-            } ?: 1 // null 일 경우 1로 세팅
-
+            // 회원가입 바텀시트 누른 후 뒤로가기할 때
+            if (step.value == 4) {
+                _step.value?.minus(2)
+            } else {
+                step.value?.minus(1)?.let { backedStep ->
+                    if (backedStep < 0) 0 else backedStep // 0 보다 작을 수 없다.
+                } ?: 1 // null 일 경우 1로 세팅
+            }
     }
 
     fun isDaySelected(content: String) = days.contains(Day.from(content))


### PR DESCRIPTION
## *Description*
* 1/3에서 뒤로가기하면 `SplashLoginActivity`로 이동합니다
* 회원가입 바텀시트 클릭 후 뒤로가기하면 바로 2/3으로 이동합니다
    * 기존에는 두 번 클릭해야 이동했었어요
* 선택 요일 값이 비었을 때 뒤로가기해도 다음 버튼 비활성화가 유지되는 오류를 수정했습니다