### PR TITLE
일기 작성하기 버튼 로직 수정, 일기 불러오기 로직 수정

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/calendar/WeeklyCalendarViewHolder.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/calendar/WeeklyCalendarViewHolder.kt
@@ -9,6 +9,7 @@ import com.sopt.smeem.databinding.ViewWeeklyCalendarDayBinding
 import com.sopt.smeem.presentation.calendar.listener.OnWeeklyDayClickListener
 import java.sql.Date
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class WeeklyCalendarViewHolder(
     private val binding: ViewWeeklyCalendarDayBinding,
@@ -16,8 +17,7 @@ class WeeklyCalendarViewHolder(
 ) :
     RecyclerView.ViewHolder(binding.root), View.OnClickListener, View.OnLongClickListener {
 
-    private lateinit var weeklyDate: LocalDate
-
+    private var weeklyDate: LocalDate = LocalDate.now()
     init {
         binding.root.setOnClickListener(this)
         binding.root.setOnLongClickListener(this)

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -52,6 +52,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 binding.btnWriteDiary.visibility = View.INVISIBLE
             }
         }
+        getWeeklyDiary()
         observeData()
     }
 
@@ -65,6 +66,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 binding.btnWriteDiary.visibility = View.INVISIBLE
             }
         }
+        getWeeklyDiary()
         observeData()
     }
 
@@ -96,6 +98,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 }
         }
 
+        getWeeklyDiary()
         showBadgeDialog()
     }
 
@@ -192,6 +195,19 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 binding.tvDiaryWritenTime.text = formattedCreatedAt
                 binding.tvDiary.text = it.content
             }
+        }
+    }
+
+    private fun getWeeklyDiary() {
+        lifecycleScope.launch {
+            homeViewModel.getDiaries(
+                start = binding.weeklyCalendar.mondayDate?.plusDays(-6)?.format(
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                ) ?: "",
+                end = binding.weeklyCalendar.mondayDate?.plusDays(6)?.format(
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                ) ?: "",
+            )
         }
     }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.sopt.smeem.R
 import com.sopt.smeem.databinding.ActivityHomeBinding
 import com.sopt.smeem.domain.model.RetrievedBadge
@@ -15,6 +16,7 @@ import com.sopt.smeem.presentation.detail.DiaryDetailActivity
 import com.sopt.smeem.presentation.mypage.MyPageActivity
 import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -40,6 +42,32 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         onTouchWrite()
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        lifecycleScope.launch {
+            homeViewModel.getDateDiary(todayData)
+
+            if (homeViewModel.responseDateDiary.value != null) {
+                binding.btnWriteDiary.visibility = View.INVISIBLE
+            }
+        }
+        observeData()
+    }
+
+    override fun onRestart() {
+        super.onRestart()
+
+        lifecycleScope.launch {
+            homeViewModel.getDateDiary(todayData)
+
+            if (homeViewModel.responseDateDiary.value != null) {
+                binding.btnWriteDiary.visibility = View.INVISIBLE
+            }
+        }
+        observeData()
+    }
+
     private fun onTouchWrite() {
         binding.btnWriteDiary.setOnSingleClickListener {
             bs.show(supportFragmentManager, TAG)
@@ -56,12 +84,24 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         binding.tvTargetMonth.text = LocalDate.now().format(
             DateTimeFormatter.ofPattern(TARGET_MONTH_PATTERN),
         )
-        homeViewModel.getDateDiary(day)
+
+        lifecycleScope.launch {
+            homeViewModel.getDateDiary(day)
+
+            binding.btnWriteDiary.visibility =
+                if (homeViewModel.responseDateDiary.value == null) {
+                    View.VISIBLE
+                } else {
+                    View.INVISIBLE
+                }
+        }
+
         showBadgeDialog()
     }
 
     private fun showBadgeDialog() {
-        val retrievedBadge = intent.getSerializableExtra("retrievedBadge") as List<RetrievedBadge>? ?: emptyList()
+        val retrievedBadge =
+            intent.getSerializableExtra("retrievedBadge") as List<RetrievedBadge>? ?: emptyList()
         if (retrievedBadge.isNotEmpty()) {
             val badgeList = retrievedBadge.asReversed()
             badgeList.map { badge ->
@@ -80,24 +120,34 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
             binding.tvTargetMonth.text =
                 date.format(DateTimeFormatter.ofPattern(TARGET_MONTH_PATTERN))
 
-            binding.btnWriteDiary.visibility =
-                if (LocalDate.now().isEqual(date) && homeViewModel.responseDateDiary.value == null) View.VISIBLE else View.INVISIBLE
+            lifecycleScope.launch {
+                homeViewModel.getDateDiary(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
 
-            homeViewModel.getDateDiary(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                binding.btnWriteDiary.visibility =
+                    if (LocalDate.now()
+                            .isEqual(date) && homeViewModel.responseDateDiary.value == null
+                    ) {
+                        View.VISIBLE
+                    } else {
+                        View.INVISIBLE
+                    }
+            }
         }
 
         binding.weeklyCalendar.setOnWeeklyCalendarSwipeListener(object :
             OnWeeklyCalendarSwipeListener {
             override fun onSwipe(mondayDate: LocalDate?) {
                 mondayDate?.let {
-                    homeViewModel.getDiaries(
-                        start = binding.weeklyCalendar.mondayDate?.plusDays(-6)?.format(
-                            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
-                        ) ?: "",
-                        end = binding.weeklyCalendar.mondayDate?.plusDays(6)?.format(
-                            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
-                        ) ?: "",
-                    )
+                    lifecycleScope.launch {
+                        homeViewModel.getDiaries(
+                            start = binding.weeklyCalendar.mondayDate?.plusDays(-6)?.format(
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                            ) ?: "",
+                            end = binding.weeklyCalendar.mondayDate?.plusDays(6)?.format(
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                            ) ?: "",
+                        )
+                    }
                     setTargetMonthTitle()
                 }
             }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
@@ -4,13 +4,10 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.sopt.smeem.domain.model.DiarySummaries
 import com.sopt.smeem.domain.model.DiarySummary
-import com.sopt.smeem.domain.model.RetrievedBadge
 import com.sopt.smeem.domain.repository.DiaryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,29 +26,25 @@ class HomeViewModel @Inject constructor(
     private val _responseDateDiary: MutableLiveData<DiarySummary?> = MutableLiveData()
     val responseDateDiary: LiveData<DiarySummary?> get() = _responseDateDiary
 
-    fun getDiaries(start: String, end: String) {
-        viewModelScope.launch {
-            kotlin.runCatching {
-                diaryRepository.getDiaries(start, end)
-            }.fold({
-                Log.e("message", it.getOrNull().toString())
-                _responseDiaries.value = it.getOrNull()
-            }, {
-                Log.e("message", it.message.toString())
-            })
-        }
+    suspend fun getDiaries(start: String, end: String) {
+        kotlin.runCatching {
+            diaryRepository.getDiaries(start, end)
+        }.fold({
+            Log.e("message", it.getOrNull().toString())
+            _responseDiaries.value = it.getOrNull()
+        }, {
+            Log.e("message", it.message.toString())
+        })
     }
 
-    fun getDateDiary(date: String) {
-        viewModelScope.launch {
-            kotlin.runCatching {
-                diaryRepository.getDiaries(start = date, end = date)
-            }.fold({
-                _responseDateDiary.value = it.getOrNull()?.diaries?.values?.firstOrNull()
-            }, {
-                Log.e("message", it.message.toString())
-            })
-        }
+    suspend fun getDateDiary(date: String) {
+        kotlin.runCatching {
+            diaryRepository.getDiaries(start = date, end = date)
+        }.fold({
+            _responseDateDiary.value = it.getOrNull()?.diaries?.values?.firstOrNull()
+        }, {
+            Log.e("message", it.message.toString())
+        })
     }
 
     fun setBadgeInfo(name: String, imageUrl: String, isFirst: Boolean) {

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -245,7 +245,7 @@
             android:paddingVertical="20dp"
             android:text="@string/write_diary"
             android:textAppearance="@style/TextAppearance.Smeem.Subtitle1_bold"
-            android:visibility="visible"
+            android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
- 에러 발생 요소를 최소화했습니다.
- 셩명주기에 따라 일기를 안전하게 불러오도록 했습니다
- 뷰모델에서 코루틴을 생성하지 않고, 액티비티에서 코루틴을 생성해 뷰 반영이 바로바로 되도록 했습니다. 

요약 : 일기 작성 후 작성버튼이 뜨지 않도록 변경, 첫 화면 진입 시 text color 정상 반영 