### PR TITLE
이전 버전일 때 업데이트 권장 (remote config)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,12 @@ android {
         minSdk 28
         targetSdk 33
         versionCode 20230829
+        /*
+        x.y.z
+        x: ui, 주요기능의 큰 변화
+        y: 기능 추가, 가시적인 변화
+        z: 오류 수정, 긴급 업데이트 사항
+        */
         versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -59,7 +65,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation 'com.google.android.material:material:1.8.0'
-
     // retrofit2
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"
@@ -87,10 +92,8 @@ dependencies {
     implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha05'
     // DataStore
     implementation 'androidx.datastore:datastore-preferences:1.0.0'
-
     // CoordinateLayout
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
-
     // RecyclerView
     implementation "androidx.recyclerview:recyclerview:1.2.1"
     // ui //
@@ -109,25 +112,22 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.0-rc01'
 
     // external //
-    // fcm
-    implementation platform('com.google.firebase:firebase-bom:31.5.0')
-    implementation 'com.google.firebase:firebase-analytics-ktx:21.2.2'
-    implementation 'com.google.firebase:firebase-messaging-ktx:23.1.2'
-
+    // firebase
+    implementation platform('com.google.firebase:firebase-bom:32.2.3')
+    implementation 'com.google.firebase:firebase-config-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-messaging-ktx'
     // test
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-
     // kakao
     implementation "com.kakao.sdk:v2-user:2.13.0"
-
     // Hilt
     implementation 'com.google.dagger:hilt-android:2.44.2'
     kapt 'com.google.dagger:hilt-compiler:2.44.2'
-
     // Timber
     implementation "com.jakewharton.timber:timber:5.0.1"
-
+    // Glide
     implementation 'com.github.bumptech.glide:glide:4.13.2'
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
@@ -8,7 +8,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.ktx.Firebase
-import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.sopt.smeem.BuildConfig
@@ -27,19 +26,13 @@ class SplashStartActivity() : AppCompatActivity() {
 
         setContentView(R.layout.activity_splash_start)
 
-        setStatusBarColor()
-
         constructLayout()
-        addObservers()
     }
 
     fun constructLayout() {
+        setStatusBarColor()
         checkVersion()
         vm.checkAuthed()
-    }
-
-    fun addObservers() {
-        observeAuthed()
     }
 
     private fun setStatusBarColor() {
@@ -76,15 +69,39 @@ class SplashStartActivity() : AppCompatActivity() {
                     if (isNewVersion) {
                         Timber.tag("smeem is updated to a new version")
                             .d("%s | %s", installedVersion, firebaseVersion)
+                        observeAuthed()
                     } else {
                         Timber.tag("smeem needs to be updated!")
                             .d("%s | %s", installedVersion, firebaseVersion)
+                        showUpdateDialog()
                     }
                 } else {
                     Timber.e("remote config failed")
                 }
             }
         }
+    }
+
+    private fun showUpdateDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle("업데이트 알림")
+            .setMessage("보다 나아진 스밈의 최신 버전을 준비했어요! 새로운 버전으로 업데이트 후 이용해주세요.")
+            .setNegativeButton("나가기") { dialog, which ->
+                Timber.d("아니요를 눌렀습니다")
+                finishSmeem()
+            }
+            .setPositiveButton("업데이트") { dialog, which ->
+                Timber.d("예를 눌렀습니다")
+                // TODO: 스토어로 이동 - 스토어 등록 후 링크 가져오기
+                observeAuthed()
+            }
+            .show()
+    }
+
+    private fun finishSmeem() {
+        moveTaskToBack(true)
+        finishAndRemoveTask()
+        System.exit(0)
     }
 
     private fun observeAuthed() {

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
@@ -84,8 +84,7 @@ class SplashStartActivity() : AppCompatActivity() {
 
     private fun showUpdateDialog() {
         MaterialAlertDialogBuilder(this)
-            .setTitle("업데이트 알림")
-            .setMessage("보다 나아진 스밈의 최신 버전을 준비했어요! 새로운 버전으로 업데이트 후 이용해주세요.")
+            .setCustomTitle(layoutInflater.inflate(R.layout.update_dialog_content, null))
             .setNegativeButton("나가기") { dialog, which ->
                 Timber.d("아니요를 눌렀습니다")
                 finishSmeem()

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
@@ -6,9 +6,16 @@ import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import com.google.firebase.remoteconfig.ktx.remoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.sopt.smeem.BuildConfig
 import com.sopt.smeem.R
 import com.sopt.smeem.presentation.home.HomeActivity
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class SplashStartActivity() : AppCompatActivity() {
@@ -27,6 +34,7 @@ class SplashStartActivity() : AppCompatActivity() {
     }
 
     fun constructLayout() {
+        checkVersion()
         vm.checkAuthed()
     }
 
@@ -37,6 +45,46 @@ class SplashStartActivity() : AppCompatActivity() {
     private fun setStatusBarColor() {
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
         window.statusBarColor = getColor(R.color.point)
+    }
+
+    private fun checkVersion() {
+        val configSettings = remoteConfigSettings {
+            minimumFetchIntervalInSeconds = 3600
+        }.toBuilder().build()
+
+        Firebase.remoteConfig.apply {
+            setConfigSettingsAsync(configSettings)
+            setDefaultsAsync(R.xml.remote_config_defaults)
+            fetch().addOnCompleteListener(this@SplashStartActivity) { task ->
+                val installedVersion = BuildConfig.VERSION_NAME.replace(".", "@")
+                val firebaseVersion =
+                    getString("app_version").takeIf { it.isNotEmpty() }?.replace(".", "@")
+                val isNewVersion = when {
+                    firebaseVersion.isNullOrEmpty() -> false
+                    else -> {
+                        val installedVersionParts = installedVersion.split("@").map { it.toInt() }
+                        val firebaseVersionParts = firebaseVersion.split("@").map { it.toInt() }
+                        installedVersionParts.zip(firebaseVersionParts)
+                            .all { (installed, firebase) ->
+                                installed >= firebase
+                            }
+                    }
+                }
+
+                if (task.isSuccessful) {
+                    activate()
+                    if (isNewVersion) {
+                        Timber.tag("smeem is updated to a new version")
+                            .d("%s | %s", installedVersion, firebaseVersion)
+                    } else {
+                        Timber.tag("smeem needs to be updated!")
+                            .d("%s | %s", installedVersion, firebaseVersion)
+                    }
+                } else {
+                    Timber.e("remote config failed")
+                }
+            }
+        }
     }
 
     private fun observeAuthed() {

--- a/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/splash/SplashStartActivity.kt
@@ -49,25 +49,22 @@ class SplashStartActivity() : AppCompatActivity() {
             setConfigSettingsAsync(configSettings)
             setDefaultsAsync(R.xml.remote_config_defaults)
             fetch().addOnCompleteListener(this@SplashStartActivity) { task ->
-                val installedVersion = BuildConfig.VERSION_NAME.replace(".", "@")
+                val installedVersion = BuildConfig.VERSION_NAME
                 val firebaseVersion =
-                    getString("app_version").takeIf { it.isNotEmpty() }?.replace(".", "@")
+                    getString("app_version").takeIf { it.isNotEmpty() }
                 val isNewVersion = when {
                     firebaseVersion.isNullOrEmpty() -> false
                     else -> {
-                        val installedVersionParts = installedVersion.split("@").map { it.toInt() }
-                        val firebaseVersionParts = firebaseVersion.split("@").map { it.toInt() }
-                        installedVersionParts.zip(firebaseVersionParts)
-                            .all { (installed, firebase) ->
-                                installed >= firebase
-                            }
+                        val installedVersionX = installedVersion.split(".").first().toInt()
+                        val firebaseVersionX = firebaseVersion.split(".").first().toInt()
+                        installedVersionX >= firebaseVersionX
                     }
                 }
 
                 if (task.isSuccessful) {
                     activate()
                     if (isNewVersion) {
-                        Timber.tag("smeem is updated to a new version")
+                        Timber.tag("smeem doesn't need to be updated")
                             .d("%s | %s", installedVersion, firebaseVersion)
                         observeAuthed()
                     } else {
@@ -86,11 +83,9 @@ class SplashStartActivity() : AppCompatActivity() {
         MaterialAlertDialogBuilder(this)
             .setCustomTitle(layoutInflater.inflate(R.layout.update_dialog_content, null))
             .setNegativeButton("나가기") { dialog, which ->
-                Timber.d("아니요를 눌렀습니다")
                 finishSmeem()
             }
             .setPositiveButton("업데이트") { dialog, which ->
-                Timber.d("예를 눌렀습니다")
                 // TODO: 스토어로 이동 - 스토어 등록 후 링크 가져오기
                 observeAuthed()
             }

--- a/app/src/main/res/layout/update_dialog_content.xml
+++ b/app/src/main/res/layout/update_dialog_content.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:text="업데이트 알림"
+        android:textAppearance="@style/TextAppearance.Smeem.Subtitle3_medium"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="24dp"
+        android:lineSpacingExtra="4sp"
+        android:text="보다 나아진 스밈의 최신 버전을 준비했어요! 새로운 버전으로 업데이트 후 이용해주세요."
+        android:textAppearance="@style/TextAppearance.Smeem.Caption3_regular"
+        android:textColor="@color/gray_600"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/tv_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<defaults>
+  <entry>
+    <key>app_version</key>
+    <value>1.0.0</value>
+  </entry>
+</defaults>


### PR DESCRIPTION
## *Related issue*
* #163 

## *Description*
* firebase의 remote config에서 파라미터 `app_version`의 값을 가져와서 현재 버전과 비교하는 방식으로 구현했습니다
* 일단은 `versionName`의 첫 숫자?가 변경되었을 때만 다이얼로그가 뜨도록 했습니다
* 업데이트 등록할 시점에 [여기서](https://console.firebase.google.com/u/5/project/smeem-303d1/config?hl=ko) 파라미터 값 바꾸면 됩니다

## *PR point*
* 물론 실질적인 업데이트 기능은 릴리즈 후에 추가 예정입니당
* 치명적인 버그나 보안상 문제가 생겨 긴급 업데이트를 해야할 상황도 대응해야하는데 조건을 뭘로 할지 고민되네요 (마지막 숫자 변경할 때로 하자니 사소한 업뎃도 그쪽에 포함될 것 같아서...) `versionName`의 규칙에 대해 한번 얘기해봐야될듯 합니다
* 아니면 안드로이드에서 지원하는 인앱 업데이트도 있는데 - 자세한 내용은 이슈에 있어요 - 이 방식으로 하면 우선순위를 0-5까지로 설정할 수 있어서 좀 더 구체적인 대응이 가능하긴 합니다
    * 일정 기간이 지나야만 업데이트 알림을 띄우게도 할수있음! <br/><br/>
* 결론은 형님들의 의견이 필요합니다 

## *Screenshot*
<img src="https://github.com/Team-Smeme/smeem-aos/assets/74162198/923d437c-a2e1-4953-a2a1-ac57761d5902" width="300">