### PR TITLE
기존 닉네임과 동일할시 다음 버튼 비활성화

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/ChangingNicknameActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/ChangingNicknameActivity.kt
@@ -45,13 +45,15 @@ class ChangingNicknameActivity :
     }
 
     private fun onTextWrite() {
-        binding.etChangeNickname.addTextChangedListener { watcher ->
-            if (watcher.isNullOrBlank() || watcher.length > 10) {
-                nextButtonOff()
-            } else {
-                nextButtonOn()
+        binding.etChangeNickname.addTextChangedListener(
+            onTextChanged = { name, _, _, _ ->
+                if (name.isNullOrBlank() || name.length > 10 || name.toString() == intent.getStringExtra("originalNickname")) {
+                    nextButtonOff()
+                } else {
+                    nextButtonOn()
+                }
             }
-        }
+        )
     }
 
     private fun onTouchBack() {


### PR DESCRIPTION
## *Description*
* 기존 닉네임 그대로 입력 후 다음 누를 때 '중복된 닉네임' 이라고 떠서 아예 비활성화하는게 더 나은 ux일 것 같았어요 