### PR TITLE
캘린더 깜빡거림 해결

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/home/calendar/SmeemCalendarImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/calendar/SmeemCalendarImpl.kt
@@ -31,13 +31,14 @@ import java.time.YearMonth
 
 @Composable
 fun SmeemCalendarImpl(
-    onDayClick: (LocalDate) -> Unit
+    onDayClick: (LocalDate) -> Unit,
 ) {
     val viewModel: HomeViewModel = viewModel()
     val dateList = viewModel.visibleDates.collectAsState()
     val selectedDate = viewModel.selectedDate.collectAsState()
     val isCalendarExpanded = viewModel.isCalendarExpanded.collectAsState()
     val currentMonth = viewModel.currentMonth.collectAsState()
+    val isLoading = viewModel.isLoading.collectAsState()
 
     SmeemCalendarImpl(
         dateList = dateList.value,
@@ -45,7 +46,8 @@ fun SmeemCalendarImpl(
         currentMonth = currentMonth.value,
         onIntent = viewModel::onIntent,
         isCalendarExpanded = isCalendarExpanded.value,
-        onDayClick = onDayClick
+        onDayClick = onDayClick,
+        isLoading = isLoading.value,
     )
 }
 
@@ -56,7 +58,8 @@ private fun SmeemCalendarImpl(
     currentMonth: YearMonth,
     onIntent: (CalendarIntent) -> Unit,
     isCalendarExpanded: Boolean,
-    onDayClick: (LocalDate) -> Unit
+    onDayClick: (LocalDate) -> Unit,
+    isLoading: Boolean,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -71,11 +74,11 @@ private fun SmeemCalendarImpl(
                         onIntent(CalendarIntent.ExpandCalendar)
                     }
                 }
-            }
+            },
     ) {
         CalendarTitle(
             selectedMonth = currentMonth,
-            modifier = Modifier.padding(vertical = 18.dp)
+            modifier = Modifier.padding(vertical = 18.dp),
         )
         WeekLabel()
         if (isCalendarExpanded) {
@@ -87,33 +90,43 @@ private fun SmeemCalendarImpl(
                     onIntent(
                         CalendarIntent.LoadNextDates(
                             startDate = yearMonth.atDay(1),
-                            period = Period.MONTH
-                        )
+                            period = Period.MONTH,
+                        ),
                     )
                 },
                 onDayClick = {
                     onIntent(CalendarIntent.SelectDate(it))
                     onDayClick(it)
-                }
+                },
+                isLoading = isLoading,
             )
         } else {
             WeeklyCalendar(
                 dateList = dateList,
                 selectedDate = selectedDate,
-                loadNextWeek = { nextWeekDate -> onIntent(CalendarIntent.LoadNextDates(nextWeekDate)) },
+                loadNextWeek = { nextWeekDate ->
+                    onIntent(
+                        CalendarIntent.LoadNextDates(
+                            startDate = nextWeekDate,
+                            period = Period.WEEK,
+                        ),
+                    )
+                },
                 loadPrevWeek = { endWeekDate ->
                     onIntent(
                         CalendarIntent.LoadNextDates(
-                            endWeekDate.minusDays(
-                                1
-                            ).getWeekStartDate()
-                        )
+                            startDate = endWeekDate.minusDays(
+                                1,
+                            ).getWeekStartDate(),
+                            period = Period.WEEK,
+                        ),
                     )
                 },
                 onDayClick = {
                     onIntent(CalendarIntent.SelectDate(it))
                     onDayClick(it)
-                }
+                },
+                isLoading = isLoading,
             )
         }
         Spacer(
@@ -123,15 +136,15 @@ private fun SmeemCalendarImpl(
                     min = when {
                         isCalendarExpanded -> 24.dp
                         else -> 4.dp
-                    }
-                )
+                    },
+                ),
         )
         CalendarToggleSlider(
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 12.dp),
         )
         Divider(
             color = gray100,
-            thickness = 4.dp
+            thickness = 4.dp,
         )
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/CalendarPager.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/CalendarPager.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import com.sopt.smeem.domain.model.Date
 import java.time.LocalDate
@@ -17,26 +15,26 @@ internal fun CalendarPager(
     dateList: Array<List<Date>>,
     loadNextDates: (date: LocalDate) -> Unit,
     loadPrevDates: (date: LocalDate) -> Unit,
-    beyondBoundsPageCount: Int = 1,
     content: @Composable (currentPage: Int) -> Unit,
 ) {
-    val pagerState = rememberPagerState(
-        initialPage = 1,
-        initialPageOffsetFraction = 0f
-    ) { /*page count*/ 3 }
+    val pagerState = rememberPagerState(initialPage = 1) { /*page count*/ 3 }
+
     LaunchedEffect(pagerState.settledPage) {
-        if (pagerState.settledPage == 2) {
-            loadNextDates(dateList[1][0].day)
-            pagerState.scrollToPage(1)
-        }
-        if (pagerState.settledPage == 0) {
-            loadPrevDates(dateList[0][0].day)
-            pagerState.scrollToPage(1)
+        when (pagerState.settledPage) {
+            0 -> {
+                loadPrevDates(dateList[0][0].day)
+                pagerState.scrollToPage(1)
+            }
+
+            2 -> {
+                loadNextDates(dateList[1][0].day)
+                pagerState.scrollToPage(1)
+            }
         }
     }
+
     HorizontalPager(
         state = pagerState,
-        beyondBoundsPageCount = beyondBoundsPageCount,
         verticalAlignment = Alignment.Top,
     ) { currentPage ->
         content(currentPage)

--- a/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/MonthlyCalendar.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/MonthlyCalendar.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.sopt.smeem.domain.model.Date
@@ -23,37 +25,47 @@ internal fun MonthlyCalendar(
     selectedDate: LocalDate,
     currentMonth: YearMonth,
     loadDatesForMonth: (YearMonth) -> Unit,
-    onDayClick: (LocalDate) -> Unit
+    onDayClick: (LocalDate) -> Unit,
+    isLoading: Boolean,
 ) {
     val itemWidth = (LocalConfiguration.current.screenWidthDp.dp - 38.dp) / 7
-    CalendarPager(
-        dateList = dateList,
-        loadNextDates = { loadDatesForMonth(currentMonth) },
-        loadPrevDates = { loadDatesForMonth(currentMonth.minusMonths(2)) }
-    ) { currentPage ->
-        FlowRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 18.dp, end = 18.dp),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            dateList[currentPage].forEachIndexed { index, date ->
-                Box(
-                    modifier = Modifier
-                        .width(itemWidth),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    DayItem(
-                        date = date.day,
-                        isSelected = date.isCurrentMonth && selectedDate == date.day,
-                        isCurrentMonth = date.isCurrentMonth,
-                        isDiaryWritten = date.isDiaryWritten,
-                        onDayClick = { onDayClick(date.day) },
-                        isFirstWeek = index < 7,
-                        isSixWeeks = dateList[currentPage].size > 35
-                    )
+
+    Box {
+        CalendarPager(
+            dateList = dateList,
+            loadNextDates = { loadDatesForMonth(currentMonth) },
+            loadPrevDates = { loadDatesForMonth(currentMonth.minusMonths(2)) },
+        ) { currentPage ->
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 18.dp, end = 18.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                dateList[currentPage].forEachIndexed { index, date ->
+                    Box(
+                        modifier = Modifier
+                            .width(itemWidth),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        DayItem(
+                            date = date.day,
+                            isSelected = date.isCurrentMonth && selectedDate == date.day,
+                            isCurrentMonth = date.isCurrentMonth,
+                            isDiaryWritten = date.isDiaryWritten,
+                            onDayClick = { onDayClick(date.day) },
+                            isFirstWeek = index < 7,
+                            isSixWeeks = dateList[currentPage].size > 35,
+                        )
+                    }
                 }
             }
+        }
+        if (isLoading) { // 로딩 상태일 때 인디케이터 표시
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center),
+                color = Color.Transparent,
+            )
         }
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/WeeklyCalendar.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/calendar/component/WeeklyCalendar.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.sopt.smeem.domain.model.Date
@@ -20,34 +23,44 @@ internal fun WeeklyCalendar(
     selectedDate: LocalDate,
     loadNextWeek: (nextWeekDate: LocalDate) -> Unit,
     loadPrevWeek: (endWeekDate: LocalDate) -> Unit,
-    onDayClick: (LocalDate) -> Unit
+    onDayClick: (LocalDate) -> Unit,
+    isLoading: Boolean,
 ) {
     val itemWidth = (LocalConfiguration.current.screenWidthDp.dp - 38.dp) / 7
-    CalendarPager(
-        dateList = dateList,
-        loadNextDates = loadNextWeek,
-        loadPrevDates = loadPrevWeek
-    ) { currentPage ->
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 18.dp, end = 18.dp),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            dateList[currentPage].forEach { date ->
-                Box(
-                    modifier = Modifier
-                        .width(itemWidth),
-                    contentAlignment = Alignment.Center
-                ) {
-                    DayItem(
-                        date = date.day,
-                        onDayClick = onDayClick,
-                        isSelected = selectedDate == date.day,
-                        isDiaryWritten = date.isDiaryWritten
-                    )
+
+    Box { // 전체를 감싸는 Box 추가
+        CalendarPager(
+            dateList = dateList,
+            loadNextDates = loadNextWeek,
+            loadPrevDates = loadPrevWeek,
+        ) { currentPage ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 18.dp, end = 18.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                dateList[currentPage].forEach { date ->
+                    Box(
+                        modifier = Modifier
+                            .width(itemWidth),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        DayItem(
+                            date = date.day,
+                            onDayClick = onDayClick,
+                            isSelected = selectedDate == date.day,
+                            isDiaryWritten = date.isDiaryWritten,
+                        )
+                    }
                 }
             }
+        }
+        if (isLoading) { // 로딩 상태일 때 인디케이터 표시
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center).size(1.dp),
+                color = Color.Transparent,
+            )
         }
     }
 }


### PR DESCRIPTION
- 페이저 문제가 아니라 데이터 로딩 과정에서 recomposition되는 문제였습니다. 
- 투명 로딩 처리를 해주었고, 데이터를 불러오는 로직보다 날짜를 세팅하는 로직을 먼저 두었습니다.

https://github.com/Team-Smeme/smeem-aos/assets/98825364/d97e8e74-4473-4c4f-b2b3-cf2e57d6eec5

편-안