### PR TITLE
[QA] 일기 삭제 시 datastore 비우기 - 일기 작성 버튼 다시 안나타는 문제 

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/detail/DiaryDetailBottomSheet.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/detail/DiaryDetailBottomSheet.kt
@@ -1,39 +1,54 @@
 package com.sopt.smeem.presentation.detail
 
-import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
-import androidx.fragment.app.setFragmentResult
-import androidx.fragment.app.viewModels
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.sopt.smeem.R
+import com.sopt.smeem.data.SmeemDataStore.RECENT_DIARY_DATE
+import com.sopt.smeem.data.SmeemDataStore.dataStore
 import com.sopt.smeem.databinding.BottomSheetDiaryDetailBinding
 import com.sopt.smeem.description
 import com.sopt.smeem.event.AmplitudeEventType
 import com.sopt.smeem.presentation.EventVM
-import com.sopt.smeem.presentation.home.HomeActivity
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class DiaryDetailBottomSheet(
     private val viewModel: DiaryDetailViewModel,
-    private val eventViewModel: EventVM
+    private val eventViewModel: EventVM,
 ) : BottomSheetDialogFragment() {
     private var _binding: BottomSheetDiaryDetailBinding? = null
     private val binding get() = requireNotNull(_binding)
 
+    private val formatter = DateTimeFormatter.ofPattern("yyyy년 M월 dd일", Locale.KOREAN)
+    private val viewModelDateStr = viewModel.date.value?.substringBeforeLast(" ") ?: ""
+    private val viewModelDate = LocalDate.parse(viewModelDateStr, formatter)
+
+    private lateinit var fragmentContext: Context
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        fragmentContext = context
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = BottomSheetDiaryDetailBinding.inflate(inflater, container, false)
+        Timber.e("viewModelDate: $viewModelDate, LocalDate.now(): ${LocalDate.now()}")
         return binding.root
     }
 
@@ -69,20 +84,28 @@ class DiaryDetailBottomSheet(
             .setPositiveButton("예") { dialog, which ->
                 viewModel.deleteDiary(
                     onSuccess = {
+                        // 오늘 작성한 일기일 때만 일기 삭제 시 datastore의 최근 일기 날짜 삭제
+                        if (viewModelDate == LocalDate.now()) {
+                            lifecycleScope.launch {
+                                fragmentContext.dataStore.edit { storage ->
+                                    storage.remove(RECENT_DIARY_DATE)
+                                }
+                            }
+                        }
                         viewModel.isDiaryDeleted.value = true
                         dismiss()
                     },
                     onError = { e ->
                         Toast.makeText(requireContext(), e.description(), Toast.LENGTH_SHORT).show()
-                    }
+                    },
                 )
             }
             .show()
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
+        super.onDestroyView()
     }
 
     companion object {


### PR DESCRIPTION
오늘 작성한 일기일 때만 일기 삭제 시 datastore의 최근 일기 날짜 삭제