### PR TITLE
[QA] 배지 다이얼로그 로직 수정

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/home/BadgeDialogFragment.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/BadgeDialogFragment.kt
@@ -5,7 +5,6 @@ import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.activity.viewModels
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -19,9 +18,14 @@ import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class BadgeDialogFragment: DialogFragment() {
+class BadgeDialogFragment : DialogFragment() {
     private val binding by lazy<DialogBadgeBinding> {
-        DataBindingUtil.inflate(requireActivity().layoutInflater, R.layout.dialog_badge, null, false)
+        DataBindingUtil.inflate(
+            requireActivity().layoutInflater,
+            R.layout.dialog_badge,
+            null,
+            false
+        )
     }
     private val viewModel by viewModels<HomeViewModel>()
     private val eventVm: EventVM by viewModels()
@@ -44,25 +48,24 @@ class BadgeDialogFragment: DialogFragment() {
 
     private fun addListeners() {
         binding.btnBadgeExit.setOnSingleClickListener {
-            dismiss()
-
-            if(arguments?.getBoolean(IS_FIRST_BADGE) == true) {
+            if (arguments?.getBoolean(IS_FIRST_BADGE) == true) {
                 eventVm.sendEvent(AmplitudeEventType.WELCOME_QUIT_CLICK)
             }
+            dismiss()
         }
         binding.btnBadgeMore.setOnSingleClickListener {
+            eventVm.sendEvent(AmplitudeEventType.BADGE_MORE_CLICK)
+
+            if (arguments?.getBoolean(IS_FIRST_BADGE) == true) {
+                eventVm.sendEvent(AmplitudeEventType.WELCOME_MORE_CLICK)
+            }
+            dismiss()
             Intent(requireContext(), MyBadgesActivity::class.java)
                 .apply {
                     putExtra(ENTER_MY_BADGES_FROM, FROM_BADGE_DIALOG)
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                 }
                 .run(::startActivity)
-            dismiss()
-            eventVm.sendEvent(AmplitudeEventType.BADGE_MORE_CLICK)
-
-            if(arguments?.getBoolean(IS_FIRST_BADGE) == true) {
-                eventVm.sendEvent(AmplitudeEventType.WELCOME_MORE_CLICK)
-            }
         }
     }
 
@@ -89,7 +92,11 @@ class BadgeDialogFragment: DialogFragment() {
         private const val IS_FIRST_BADGE = "isFirstBadge"
         const val FROM_BADGE_DIALOG = "fromBadgeDialog"
 
-        fun newInstance(name: String, imageUrl: String, isFirstBadge: Boolean) : BadgeDialogFragment {
+        fun newInstance(
+            name: String,
+            imageUrl: String,
+            isFirstBadge: Boolean
+        ): BadgeDialogFragment {
             val args = Bundle().apply {
                 putString(BADGE_NAME, name)
                 putString(BADGE_IMAGE_URL, imageUrl)

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -142,13 +142,21 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
 
     private fun showBadgeDialog() {
         val retrievedBadge =
-            intent.getSerializableExtra("retrievedBadge") as List<RetrievedBadge>? ?: emptyList()
+            intent.getSerializableExtra("retrievedBadge") as List<RetrievedBadge>?
+                ?: emptyList()
         if (retrievedBadge.isNotEmpty()) {
             val badgeList = retrievedBadge.asReversed()
             badgeList.map { badge ->
-                BadgeDialogFragment
-                    .newInstance(badge.name, badge.imageUrl, homeViewModel.isFirstBadge)
-                    .show(supportFragmentManager, "badgeDialog")
+                supportFragmentManager
+                    .beginTransaction()
+                    .add(
+                        BadgeDialogFragment.newInstance(
+                            badge.name,
+                            badge.imageUrl,
+                            homeViewModel.isFirstBadge
+                        ), "badgeDialog"
+                    )
+                    .commitAllowingStateLoss()
                 with(homeViewModel) {
                     if (isFirstBadge) isFirstBadge = false
                 }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -137,6 +137,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         val msg = intent.getStringExtra("snackbarText")
         if (msg != null) {
             DefaultSnackBar.make(binding.root, msg).show()
+            intent.removeExtra("snackbarText")
         }
     }
 
@@ -161,6 +162,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                     if (isFirstBadge) isFirstBadge = false
                 }
             }
+            intent.removeExtra("retrievedBadge")
         }
     }
 


### PR DESCRIPTION
* 내가 나중에 보려고 자세히 써봄

[첫 로그인 및 홈 진입 → 마이페이지 → 뒤로가기 시 튕김](https://smeem.notion.site/e1cb64c5e7d24bbbaf24b4a8654c9d37?pvs=4) 이 이슈의 원인이 웰컴 배지 다이얼로그 때문이었더라고요
`Fragment.show(supportFragmentManager, "badgeDialog")` 가 가끔씩 이런 에러를 터뜨려서
> java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState

`.commitAllowingStateLoss()` 로 바꿔주었습니당
이 과정에서 add로 변경했다보니 다이얼로그가 스택에 누적되고, 홈에서 다른 화면으로 이동해도 intent 값이 남아있어서 (마이페이지에선 홈 화면을 변경하는 작업을 하지 않기 때문에 서버통신 횟수 줄이고자 finish() 사용안함)  extra 값을 지워주는 작업도 진행했어요

## Reference
https://satisfactoryplace.tistory.com/392

<img width="600" alt="image" src="https://github.com/Team-Smeme/smeem-aos/assets/74162198/019c104e-886e-4865-a323-9adfed35a8f4">