### PR TITLE
[QA] 초기진입 시 visibledate update

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
@@ -46,7 +46,7 @@ class HomeViewModel @Inject constructor(
 
     // diary
     private val _diaryDateList: MutableStateFlow<List<LocalDate>> = MutableStateFlow(emptyList())
-    val diaryDateList: StateFlow<List<LocalDate>> = _diaryDateList.asStateFlow()
+//    val diaryDateList: StateFlow<List<LocalDate>> = _diaryDateList.asStateFlow()
 
     private val _diaryList: MutableLiveData<DiarySummary?> = MutableLiveData()
     val diaryList: LiveData<DiarySummary?>
@@ -178,6 +178,14 @@ class HomeViewModel @Inject constructor(
                     Period.MONTH -> getDates(startDate, Period.MONTH)
                 },
             )
+
+            _visibleDates.emit(
+                when (period) {
+                    Period.WEEK -> calculateWeeklyCalendarDays(startDate)
+                    Period.MONTH -> calculateMonthlyCalendarDays(startDate)
+                },
+            )
+
             _isLoading.emit(false)
         }
     }
@@ -196,7 +204,7 @@ class HomeViewModel @Inject constructor(
         val dateList = mutableListOf<Date>()
 
         startDate.getNextDates(THREE_WEEKS).map {
-            dateList.add(Date(it, true, diaryDateList.value?.contains(it) == true))
+            dateList.add(Date(it, true, _diaryDateList.value.contains(it)))
         }
         return Array(DATELIST_SIZE) {
             dateList.slice(it * 7 until (it + 1) * 7)
@@ -211,17 +219,17 @@ class HomeViewModel @Inject constructor(
             monthFirstDate.getWeekStartDate().let { weekBeginningDate ->
                 if (weekBeginningDate != monthFirstDate) {
                     weekBeginningDate.getRemainingDatesInMonth().map {
-                        Date(it, false, diaryDateList.value?.contains(it) == true)
+                        Date(it, false, _diaryDateList.value?.contains(it) == true)
                     }
                 } else {
                     listOf()
                 } +
                     monthFirstDate.getNextDates(monthFirstDate.month.length(monthFirstDate.isLeapYear))
                         .map {
-                            Date(it, true, diaryDateList.value?.contains(it) == true)
+                            Date(it, true, _diaryDateList.value?.contains(it) == true)
                         } +
                     monthLastDate.getRemainingDatesInWeek().map {
-                        Date(it, false, diaryDateList.value?.contains(it) == true)
+                        Date(it, false, _diaryDateList.value?.contains(it) == true)
                     }
             }
         }


### PR DESCRIPTION

https://github.com/Team-Smeme/smeem-aos/assets/98825364/ec2c56bf-1493-44f3-9443-0893868d42d2

이전 깜빡임 이슈에서 _visibleDates 방출 순서를 조정하여 해결했으나 아이러니하게도 초기 진입 시에서 만큼은 원래 순서대로 해야되더군요 _diaryDateList와 얽혀있어서 그런가 봅니다. 

급한대로 값을 두 번 방출해서 해결했으나 매우 좋지 않은 방법이기에 리펙토링이 필수적인 것 같습니다..!
돌려보시고 문제있으시면 말씀해주세요