### PR TITLE
[마이페이지] 더보기 화면 구현 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,6 +189,8 @@ dependencies {
     implementation(libs.glide)
     // Amplitude
     implementation(libs.analytics.android)
+    // Browser
+    implementation(libs.androidx.browser)
 
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemDialog.kt
@@ -1,0 +1,81 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
+import com.sopt.smeem.presentation.theme.Typography
+import com.sopt.smeem.presentation.theme.black
+import com.sopt.smeem.presentation.theme.gray600
+import com.sopt.smeem.presentation.theme.point
+import com.sopt.smeem.presentation.theme.white
+
+@Composable
+fun SmeemDialog(
+    setShowDialog: (Boolean) -> Unit,
+    title: String,
+    content: String,
+    onConfirmButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = { setShowDialog(false) },
+        title = {
+            Text(
+                text = title,
+                style = Typography.titleSmall,
+                color = black
+            )
+        },
+        text = {
+            Text(
+                text = content,
+                style = Typography.labelMedium,
+                color = gray600
+            )
+        },
+        shape = RoundedCornerShape(10.dp),
+        containerColor = white,
+        confirmButton = {
+            TextButton(
+                onClick = onConfirmButtonClick
+            ) {
+                Text(
+                    text = stringResource(R.string.smeem_dialog_yes),
+                    style = Typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = point
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { setShowDialog(false) }) {
+                Text(
+                    text = stringResource(R.string.smeem_dialog_no),
+                    style = Typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = point
+                )
+            }
+        },
+        modifier = modifier.fillMaxWidth()
+    )
+
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun SmeemDialogPreview() {
+    SmeemDialog(
+        setShowDialog = {},
+        title = "Title",
+        content = "Content Content Content Content",
+        onConfirmButtonClick = {},
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
@@ -1,13 +1,23 @@
 package com.sopt.smeem.presentation.mypage.more
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.sopt.smeem.R
+import com.sopt.smeem.presentation.theme.Typography
+import com.sopt.smeem.presentation.theme.black
+import com.sopt.smeem.presentation.theme.gray600
+import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
 fun MoreScreen(
@@ -15,11 +25,74 @@ fun MoreScreen(
     modifier: Modifier
 ) {
     Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
     ) {
-        Text(text = "더보기 화면이다")
+
+        VerticalSpacer(height = 30.dp)
+
+        Text(
+            text = stringResource(R.string.my_page_more_information),
+            style = Typography.titleMedium,
+            color = black
+        )
+
+        VerticalSpacer(height = 9.dp)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.my_page_more_instructions),
+                style = Typography.bodyMedium,
+                color = gray600
+            )
+        }
+
+        VerticalSpacer(height = 60.dp)
+
+        Text(
+            text = stringResource(R.string.my_page_more_account_management),
+            style = Typography.titleMedium,
+            color = black
+        )
+
+        VerticalSpacer(height = 10.dp)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.my_page_more_logout),
+                style = Typography.bodyMedium,
+                color = gray600
+            )
+        }
+
+        VerticalSpacer(height = 6.dp)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.my_page_more_delete_account),
+                style = Typography.bodyMedium,
+                color = gray600
+            )
+        }
 
     }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun MoreScreenPreview() {
+    MoreScreen(navController = rememberNavController(), modifier = Modifier)
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
@@ -1,5 +1,7 @@
 package com.sopt.smeem.presentation.mypage.more
 
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,9 +10,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.sopt.smeem.R
@@ -18,12 +22,16 @@ import com.sopt.smeem.presentation.theme.Typography
 import com.sopt.smeem.presentation.theme.black
 import com.sopt.smeem.presentation.theme.gray600
 import com.sopt.smeem.util.VerticalSpacer
+import com.sopt.smeem.util.noRippleClickable
 
 @Composable
 fun MoreScreen(
     navController: NavController,
     modifier: Modifier
 ) {
+    val viewModel: MoreViewModel = hiltViewModel()
+    val context = LocalContext.current
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -43,10 +51,22 @@ fun MoreScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .noRippleClickable {
+                    CustomTabsIntent
+                        .Builder()
+                        .build()
+                        .run {
+                            launchUrl(
+                                context, Uri.parse(
+                                    context.getString(R.string.my_page_more_manual_link)
+                                )
+                            )
+                        }
+                }
                 .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(
-                text = stringResource(R.string.my_page_more_instructions),
+                text = stringResource(R.string.my_page_more_manual),
                 style = Typography.bodyMedium,
                 color = gray600
             )

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
@@ -4,10 +4,10 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,7 +28,6 @@ import com.sopt.smeem.presentation.theme.Typography
 import com.sopt.smeem.presentation.theme.black
 import com.sopt.smeem.presentation.theme.gray600
 import com.sopt.smeem.util.VerticalSpacer
-import com.sopt.smeem.util.noRippleClickable
 
 @Composable
 fun MoreScreen(
@@ -83,27 +82,26 @@ fun MoreScreen(
 
         VerticalSpacer(height = 9.dp)
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .noRippleClickable {
-                    CustomTabsIntent
-                        .Builder()
-                        .build()
-                        .run {
-                            launchUrl(
-                                context, Uri.parse(
-                                    context.getString(R.string.manual_url)
-                                )
+
+        Box(modifier = Modifier
+            .clickable {
+                CustomTabsIntent
+                    .Builder()
+                    .build()
+                    .run {
+                        launchUrl(
+                            context, Uri.parse(
+                                context.getString(R.string.manual_url)
                             )
-                        }
-                }
-                .padding(vertical = 12.dp, horizontal = 8.dp)
+                        )
+                    }
+            }
+            .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(
                 text = stringResource(R.string.my_page_more_manual),
                 style = Typography.bodyMedium,
-                color = gray600
+                color = gray600,
             )
         }
 
@@ -112,21 +110,20 @@ fun MoreScreen(
         Text(
             text = stringResource(R.string.my_page_more_account_management),
             style = Typography.titleMedium,
-            color = black
+            color = black,
         )
 
         VerticalSpacer(height = 10.dp)
 
         Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .noRippleClickable { setShowLogoutDialog(true) }
+                .clickable { setShowLogoutDialog(true) }
                 .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(
                 text = stringResource(R.string.my_page_more_logout),
                 style = Typography.bodyMedium,
-                color = gray600
+                color = gray600,
             )
         }
 
@@ -134,17 +131,15 @@ fun MoreScreen(
 
         Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .noRippleClickable { setShowDeleteDialog(true) }
+                .clickable { setShowDeleteDialog(true) }
                 .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(
                 text = stringResource(R.string.my_page_more_delete_account),
                 style = Typography.bodyMedium,
-                color = gray600
+                color = gray600,
             )
         }
-
     }
 }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreScreen.kt
@@ -1,5 +1,7 @@
 package com.sopt.smeem.presentation.mypage.more
 
+import android.app.Activity
+import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.Box
@@ -9,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -18,6 +22,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.sopt.smeem.R
+import com.sopt.smeem.presentation.compose.components.SmeemDialog
+import com.sopt.smeem.presentation.splash.SplashLoginActivity
 import com.sopt.smeem.presentation.theme.Typography
 import com.sopt.smeem.presentation.theme.black
 import com.sopt.smeem.presentation.theme.gray600
@@ -31,6 +37,35 @@ fun MoreScreen(
 ) {
     val viewModel: MoreViewModel = hiltViewModel()
     val context = LocalContext.current
+
+    val (showLogoutDialog, setShowLogoutDialog) = rememberSaveable { mutableStateOf(false) }
+    val (showDeleteDialog, setShowDeleteDialog) = rememberSaveable { mutableStateOf(false) }
+
+    if (showLogoutDialog) {
+        SmeemDialog(
+            setShowDialog = setShowLogoutDialog,
+            title = stringResource(R.string.smeem_dialog_logout_title),
+            content = stringResource(R.string.smeem_dialog_logout_content),
+            onConfirmButtonClick = {
+                viewModel.clearLocal()
+                context.startActivity(Intent(context, SplashLoginActivity::class.java))
+                (context as? Activity)?.finishAffinity()
+            })
+    }
+
+    // 계정 삭제 대화상자
+    if (showDeleteDialog) {
+        SmeemDialog(
+            setShowDialog = setShowDeleteDialog,
+            title = stringResource(R.string.smeem_dialog_delete_account_title),
+            content = stringResource(R.string.smeem_dialog_delete_dialog_content),
+            onConfirmButtonClick = {
+                viewModel.withdrawal()
+                context.startActivity(Intent(context, SplashLoginActivity::class.java))
+                (context as? Activity)?.finishAffinity()
+            })
+    }
+
 
     Column(
         modifier = modifier
@@ -58,7 +93,7 @@ fun MoreScreen(
                         .run {
                             launchUrl(
                                 context, Uri.parse(
-                                    context.getString(R.string.my_page_more_manual_link)
+                                    context.getString(R.string.manual_url)
                                 )
                             )
                         }
@@ -85,6 +120,7 @@ fun MoreScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .noRippleClickable { setShowLogoutDialog(true) }
                 .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(
@@ -99,6 +135,7 @@ fun MoreScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .noRippleClickable { setShowDeleteDialog(true) }
                 .padding(vertical = 12.dp, horizontal = 8.dp)
         ) {
             Text(

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/more/MoreViewModel.kt
@@ -1,0 +1,30 @@
+package com.sopt.smeem.presentation.mypage.more
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kakao.sdk.user.UserApiClient
+import com.sopt.smeem.domain.repository.LocalRepository
+import com.sopt.smeem.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MoreViewModel @Inject constructor(
+    private val localRepository: LocalRepository,
+    private val userRepository: UserRepository
+) : ViewModel() {
+    fun clearLocal() {
+        viewModelScope.launch {
+            localRepository.clear()
+        }
+    }
+
+    fun withdrawal() {
+        viewModelScope.launch {
+            userRepository.deleteUser()
+            UserApiClient.instance.unlink {}
+            localRepository.clear()
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,5 +94,12 @@
     <string name="my_page_more_account_management">계정 관리</string>
     <string name="my_page_more_logout">로그아웃</string>
     <string name="my_page_more_delete_account">계정 삭제</string>
-    <string name="my_page_more_manual_link"><![CDATA[https://www.youtube.com/watch?v=IMWT6937uUs&ab_channel=NerdConnection-Topic]]></string>
+
+    <!-- Smeem Dialog -->
+    <string name="smeem_dialog_yes">예</string>
+    <string name="smeem_dialog_no">아니요</string>
+    <string name="smeem_dialog_logout_title">로그아웃</string>
+    <string name="smeem_dialog_logout_content">로그아웃 하시겠습니까?</string>
+    <string name="smeem_dialog_delete_account_title">계정을 삭제하시겠습니까?</string>
+    <string name="smeem_dialog_delete_dialog_content">이전에 작성했던 일기는 모두 사라집니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,14 @@
     <string name="my_page_alarm">학습 알림</string>
     <string name="language_english">English</string>
     <string name="edit_target_language">edit target language</string>
+    
     <string name="my_page_change_nickname">닉네임 변경</string>
     <string name="my_page_change_nickname_button">완료</string>
+
+    <!- My Page More View>
+    <string name="my_page_more_information">정보</string>
+    <string name="my_page_more_instructions">이용 안내</string>
+    <string name="my_page_more_account_management">계정 관리</string>
+    <string name="my_page_more_logout">로그아웃</string>
+    <string name="my_page_more_delete_account">계정 삭제</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,10 +88,11 @@
     <string name="my_page_change_nickname">닉네임 변경</string>
     <string name="my_page_change_nickname_button">완료</string>
 
-    <!- My Page More View>
+    <!-- My Page More View -->
     <string name="my_page_more_information">정보</string>
-    <string name="my_page_more_instructions">이용 안내</string>
+    <string name="my_page_more_manual">이용 안내</string>
     <string name="my_page_more_account_management">계정 관리</string>
     <string name="my_page_more_logout">로그아웃</string>
     <string name="my_page_more_delete_account">계정 삭제</string>
+    <string name="my_page_more_manual_link"><![CDATA[https://www.youtube.com/watch?v=IMWT6937uUs&ab_channel=NerdConnection-Topic]]></string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ securityCryptoKtx = "1.1.0-alpha05"
 timber = "5.0.1"
 v2User = "2.13.0"
 kotlin = "1.9.22"
+browser = "1.8.0"
 
 [libraries]
 analytics-android = { module = "com.amplitude:analytics-android", version.ref = "analyticsAndroid" }
@@ -99,6 +100,7 @@ retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit
 secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "v2User" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- closed #253 

## *⛳️ Work Description*
- 컴포즈로 다시 그랬습니다
- 웹 뷰 이동 과정을 Chrome Custom Tab 라이브러리 써서 더 좋게 했습니다.
- SmeemDialog 컴포넌트 만들고 적용했습니다.
- 일단 원래 MyPageVM에 있던 더보기 화면에서 쓰이는 로직 그대로 가져와서 뷰모델 만들었는데 일단 이대로 두겠습니다 @daehwan2da 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/Team-Smeme/smeem-aos/assets/98825364/3f11de24-1677-4951-970d-e4b6d8af4faa


## *📢 To Reviewers*
- 이상한 거 있으면 말해주세요~ 
