### PR TITLE
[마이페이지] 설정 - 학습알림 뷰, 학습알림 수정 페이지 뷰 구현 

### DIFF
--- a/app/src/main/java/com/sopt/smeem/domain/model/Day.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/model/Day.kt
@@ -1,6 +1,6 @@
 package com.sopt.smeem.domain.model
 
-enum class Day(private val korean: String) {
+enum class Day(val korean: String) {
     MON("월"),
     TUE("화"),
     WED("수"),

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/Picker.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/Picker.kt
@@ -1,0 +1,132 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@Composable
+fun rememberPickerState() = remember { PickerState() }
+
+class PickerState {
+    var selectedItem by mutableStateOf("")
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun Picker(
+    items: List<String>,
+    state: PickerState = rememberPickerState(),
+    modifier: Modifier = Modifier,
+    startIndex: Int = 0,
+    visibleItemsCount: Int = 3,
+    textModifier: Modifier = Modifier,
+    textStyle: TextStyle = LocalTextStyle.current,
+    dividerColor: Color = LocalContentColor.current,
+) {
+
+    val visibleItemsMiddle = visibleItemsCount / 2
+    val listScrollCount = Integer.MAX_VALUE
+    val listScrollMiddle = listScrollCount / 2
+    val listStartIndex =
+        listScrollMiddle - listScrollMiddle % items.size - visibleItemsMiddle + startIndex
+
+    fun getItem(index: Int) = items[index % items.size]
+
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    val itemHeightPixels = remember { mutableStateOf(0) }
+    val itemHeightDp = pixelsToDp(itemHeightPixels.value)
+
+    val fadingEdgeGradient = remember {
+        Brush.verticalGradient(
+            0f to Color.Transparent,
+            0.5f to Color.Black,
+            1f to Color.Transparent
+        )
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .map { index -> getItem(index + visibleItemsMiddle) }
+            .distinctUntilChanged()
+            .collect { item -> state.selectedItem = item }
+    }
+
+    Box(modifier = modifier) {
+
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(itemHeightDp * visibleItemsCount)
+                .fadingEdge(fadingEdgeGradient)
+        ) {
+            items(listScrollCount) { index ->
+                Text(
+                    text = getItem(index),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = textStyle,
+                    modifier = Modifier
+                        .onSizeChanged { size -> itemHeightPixels.value = size.height }
+                        .then(textModifier)
+                )
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.offset(y = itemHeightDp * visibleItemsMiddle),
+            color = dividerColor
+        )
+
+        HorizontalDivider(
+            modifier = Modifier.offset(y = itemHeightDp * (visibleItemsMiddle + 1)),
+            color = dividerColor
+        )
+
+    }
+
+}
+
+private fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
+
+@Composable
+private fun pixelsToDp(pixels: Int) = with(LocalDensity.current) { pixels.toDp() }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -1,7 +1,6 @@
 package com.sopt.smeem.presentation.compose.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.sopt.smeem.R
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.presentation.compose.theme.Typography
+import com.sopt.smeem.presentation.compose.theme.gray200
 import com.sopt.smeem.presentation.compose.theme.gray500
 import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.compose.theme.white
@@ -52,7 +52,8 @@ fun SmeemAlarmCard(
         ) {
             items(daysOfWeek.size) { day ->
                 val daySelected = isDaySelected(daysOfWeek[day])
-                val borderColor = if (daySelected) point else gray500
+                val borderColor = if (daySelected) point else gray200
+                val sideBorder = Border(strokeWidth = 1.dp, color = borderColor)
 
                 val radiusModifier = when (day) {
                     0 -> Modifier.clip(RoundedCornerShape(topStart = 6.dp))
@@ -63,37 +64,36 @@ fun SmeemAlarmCard(
                 val itemModifier = Modifier
                     .size(itemWidth)
                     .then(radiusModifier)
+                    .background(if (daySelected) point else white)
                     .then(
                         if (!daySelected) {
                             Modifier
                                 .let { modifier ->
                                     when (day) {
                                         0 -> {
-                                            modifier.border(
-                                                1.dp,
-                                                color = borderColor,
-                                                RoundedCornerShape(topStart = 6.dp)
+                                            modifier.sideBorder(
+                                                topStart = sideBorder,
+                                                bottom = sideBorder
                                             )
                                         }
 
                                         daysOfWeek.size - 1 -> {
-                                            modifier
-                                                .border(
-                                                    width = 1.dp,
-                                                    color = borderColor,
-                                                    shape = RoundedCornerShape(topEnd = 6.dp)
-                                                )
+                                            modifier.sideBorder(
+                                                topEnd = sideBorder,
+                                                bottom = sideBorder
+                                            )
                                         }
 
                                         else -> modifier.sideBorder(
-                                            top = Border(1.dp, borderColor),
+                                            top = sideBorder,
+                                            bottom = sideBorder
                                         )
                                     }
                                 }
                                 .padding(1.dp)
                         } else Modifier
                     )
-                    .background(if (daySelected) point else white)
+
 
                 Box(
                     contentAlignment = Alignment.Center,
@@ -108,13 +108,15 @@ fun SmeemAlarmCard(
             }
         }
 
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(bottomStart = 6.dp, bottomEnd = 6.dp))
                 .background(white)
-                .border(1.dp, gray500, RoundedCornerShape(bottomStart = 6.dp, bottomEnd = 6.dp)),
+                .sideBorder(
+                    bottomStart = Border(1.dp, gray200),
+                    bottomEnd = Border(1.dp, gray200)
+                )
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -37,7 +37,7 @@ fun SmeemAlarmCard(
     onAlarmCardClick: () -> Unit = {},
     isContentClickable: Boolean = false,
     onDayClick: (String) -> Unit = {},
-    onTimeClick: () -> Unit = {}
+    onTimeCardClick: () -> Unit = {}
 ) {
 
     val daysOfWeek = Day.entries.map { it.korean }
@@ -130,6 +130,11 @@ fun SmeemAlarmCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .then(
+                        if (isContentClickable) {
+                            Modifier.noRippleClickable { onTimeCardClick() }
+                        } else Modifier
+                    )
                     .padding(vertical = 20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -26,13 +26,18 @@ import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.compose.theme.white
 import com.sopt.smeem.util.Border
 import com.sopt.smeem.util.VerticalSpacer
+import com.sopt.smeem.util.noRippleClickable
 import com.sopt.smeem.util.sideBorder
 
 @Composable
 fun SmeemAlarmCard(
     modifier: Modifier = Modifier,
     isDaySelected: (String) -> Boolean,
-    trainingTime: String = stringResource(R.string.default_training_time)
+    trainingTime: String = stringResource(R.string.default_training_time),
+    onAlarmCardClick: () -> Unit = {},
+    isContentClickable: Boolean = false,
+    onDayClick: (String) -> Unit = {},
+    onTimeClick: () -> Unit = {}
 ) {
 
     val daysOfWeek = Day.entries.map { it.korean }
@@ -43,7 +48,11 @@ fun SmeemAlarmCard(
         (screenWidth - 38.dp) / daysOfWeek.size
     }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .noRippleClickable { onAlarmCardClick() }
+    ) {
         LazyRow(
             modifier = Modifier
                 .fillMaxWidth()
@@ -145,8 +154,8 @@ fun SmeemAlarmCard(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SmeemAlarmDaysPreview() {
-    val mockDays = listOf("월", "화", "수", "목", "금")
+    val mockDays = arrayOf("월", "화", "수", "목", "금")
     SmeemAlarmCard(
         modifier = Modifier.padding(horizontal = 19.dp),
-        isDaySelected = { mockDays.contains(it) })
+        isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -19,14 +19,18 @@ import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.gray100
 import com.sopt.smeem.presentation.compose.theme.gray400
+import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.compose.theme.white
 
 @Composable
-fun SmeemAlarmDays(
+fun SmeemAlarmCard(
     modifier: Modifier = Modifier,
+    isDaySelected: (String) -> Boolean
 ) {
 
     val daysOfWeek = Day.entries.map { it.korean }
+
+    // 화면의 가로 길이를 가져와서 요일의 개수로 나누어 요일의 너비를 계산
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val itemWidth = with(LocalConfiguration.current) {
         (screenWidth - 38.dp) / daysOfWeek.size
@@ -43,13 +47,23 @@ fun SmeemAlarmDays(
         items(daysOfWeek.size) { day ->
             Box(
                 contentAlignment = Alignment.Center,
-                modifier = Modifier.size(itemWidth),
+                modifier = Modifier
+                    .size(itemWidth)
+                    .then(if (isDaySelected(daysOfWeek[day])) Modifier.background(point) else Modifier)
             ) {
-                Text(
-                    text = daysOfWeek[day],
-                    style = Typography.bodySmall,
-                    color = gray400,
-                )
+                if (isDaySelected(daysOfWeek[day])) {
+                    Text(
+                        text = daysOfWeek[day],
+                        style = Typography.bodySmall,
+                        color = white,
+                    )
+                } else {
+                    Text(
+                        text = daysOfWeek[day],
+                        style = Typography.bodySmall,
+                        color = gray400,
+                    )
+                }
             }
         }
     }
@@ -58,5 +72,6 @@ fun SmeemAlarmDays(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SmeemAlarmDaysPreview() {
-    SmeemAlarmDays()
+    val mockDays = listOf("월", "화", "수", "목", "금")
+    SmeemAlarmCard(modifier = Modifier, isDaySelected = { mockDays.contains(it) })
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -3,7 +3,9 @@ package com.sopt.smeem.presentation.compose.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,19 +15,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.presentation.compose.theme.Typography
-import com.sopt.smeem.presentation.compose.theme.gray100
-import com.sopt.smeem.presentation.compose.theme.gray400
+import com.sopt.smeem.presentation.compose.theme.gray500
 import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.compose.theme.white
+import com.sopt.smeem.util.Border
+import com.sopt.smeem.util.VerticalSpacer
+import com.sopt.smeem.util.sideBorder
 
 @Composable
 fun SmeemAlarmCard(
     modifier: Modifier = Modifier,
-    isDaySelected: (String) -> Boolean
+    isDaySelected: (String) -> Boolean,
+    trainingTime: String = stringResource(R.string.default_training_time)
 ) {
 
     val daysOfWeek = Day.entries.map { it.korean }
@@ -36,34 +43,98 @@ fun SmeemAlarmCard(
         (screenWidth - 38.dp) / daysOfWeek.size
     }
 
-    LazyRow(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
-            .background(white)
-            .border(1.dp, gray100, RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
+                .background(white)
+        ) {
+            items(daysOfWeek.size) { day ->
+                val daySelected = isDaySelected(daysOfWeek[day])
+                val borderColor = if (daySelected) point else gray500
 
-        items(daysOfWeek.size) { day ->
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
+                val radiusModifier = when (day) {
+                    0 -> Modifier.clip(RoundedCornerShape(topStart = 6.dp))
+                    daysOfWeek.size - 1 -> Modifier.clip(RoundedCornerShape(topEnd = 6.dp))
+                    else -> Modifier
+                }
+
+                val itemModifier = Modifier
                     .size(itemWidth)
-                    .then(if (isDaySelected(daysOfWeek[day])) Modifier.background(point) else Modifier)
-            ) {
-                if (isDaySelected(daysOfWeek[day])) {
-                    Text(
-                        text = daysOfWeek[day],
-                        style = Typography.bodySmall,
-                        color = white,
+                    .then(radiusModifier)
+                    .then(
+                        if (!daySelected) {
+                            Modifier
+                                .let { modifier ->
+                                    when (day) {
+                                        0 -> {
+                                            modifier.border(
+                                                1.dp,
+                                                color = borderColor,
+                                                RoundedCornerShape(topStart = 6.dp)
+                                            )
+                                        }
+
+                                        daysOfWeek.size - 1 -> {
+                                            modifier
+                                                .border(
+                                                    width = 1.dp,
+                                                    color = borderColor,
+                                                    shape = RoundedCornerShape(topEnd = 6.dp)
+                                                )
+                                        }
+
+                                        else -> modifier.sideBorder(
+                                            top = Border(1.dp, borderColor),
+                                        )
+                                    }
+                                }
+                                .padding(1.dp)
+                        } else Modifier
                     )
-                } else {
+                    .background(if (daySelected) point else white)
+
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = itemModifier
+                ) {
                     Text(
                         text = daysOfWeek[day],
                         style = Typography.bodySmall,
-                        color = gray400,
+                        color = if (daySelected) white else gray500,
                     )
                 }
+            }
+        }
+
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(bottomStart = 6.dp, bottomEnd = 6.dp))
+                .background(white)
+                .border(1.dp, gray500, RoundedCornerShape(bottomStart = 6.dp, bottomEnd = 6.dp)),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.my_page_setting_training_time_title),
+                    style = Typography.labelLarge,
+                    color = point
+                )
+
+                VerticalSpacer(height = 4.dp)
+
+                Text(
+                    text = trainingTime,
+                    style = Typography.titleMedium,
+                    color = point
+                )
             }
         }
     }
@@ -73,5 +144,7 @@ fun SmeemAlarmCard(
 @Composable
 fun SmeemAlarmDaysPreview() {
     val mockDays = listOf("월", "화", "수", "목", "금")
-    SmeemAlarmCard(modifier = Modifier, isDaySelected = { mockDays.contains(it) })
+    SmeemAlarmCard(
+        modifier = Modifier.padding(horizontal = 19.dp),
+        isDaySelected = { mockDays.contains(it) })
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmDays.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmDays.kt
@@ -1,0 +1,62 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.domain.model.Day
+import com.sopt.smeem.presentation.compose.theme.Typography
+import com.sopt.smeem.presentation.compose.theme.gray100
+import com.sopt.smeem.presentation.compose.theme.gray400
+import com.sopt.smeem.presentation.compose.theme.white
+
+@Composable
+fun SmeemAlarmDays(
+    modifier: Modifier = Modifier,
+) {
+
+    val daysOfWeek = Day.entries.map { it.korean }
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val itemWidth = with(LocalConfiguration.current) {
+        (screenWidth - 38.dp) / daysOfWeek.size
+    }
+
+    LazyRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
+            .background(white)
+            .border(1.dp, gray100, RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
+    ) {
+
+        items(daysOfWeek.size) { day ->
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.size(itemWidth),
+            ) {
+                Text(
+                    text = daysOfWeek[day],
+                    style = Typography.bodySmall,
+                    color = gray400,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun SmeemAlarmDaysPreview() {
+    SmeemAlarmDays()
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
@@ -1,0 +1,173 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.sopt.smeem.presentation.compose.theme.Typography
+import com.sopt.smeem.presentation.compose.theme.black
+import com.sopt.smeem.presentation.compose.theme.point
+import com.sopt.smeem.presentation.compose.theme.white
+import com.sopt.smeem.util.HorizontalSpacer
+import com.sopt.smeem.util.VerticalSpacer
+
+@Composable
+fun SmeemTimePickerDialog(
+    setShowDialog: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
+    onSaveButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+
+    val timeOfDay = remember { listOf("오전", "오후") }
+    val hour = remember { (1..12).map { it.toString() } }
+    val minute = remember { listOf("00", "30") }
+
+    val timeOfDayPickerState = rememberPickerState()
+    val hourPickerState = rememberPickerState()
+    val minutePickerState = rememberPickerState()
+
+    Dialog(onDismissRequest = onDismissRequest) {
+        Surface(
+            modifier = modifier
+                .fillMaxWidth()
+                .width(screenWidth - 36.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(10.dp),
+            color = white
+        ) {
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .wrapContentSize()
+                    .padding(top = 30.dp)
+            ) {
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 30.dp),
+                    verticalAlignment = Alignment.Top
+                ) {
+
+                    Picker(
+                        state = timeOfDayPickerState,
+                        items = timeOfDay,
+                        visibleItemsCount = 2,
+                        textModifier = Modifier.padding(18.dp),
+                        modifier = Modifier.weight(1f),
+                        textStyle = Typography.titleSmall.copy(color = black),
+                        dividerColor = point,
+                    )
+
+                    HorizontalSpacer(width = 24.dp)
+
+                    Picker(
+                        state = hourPickerState,
+                        items = hour,
+                        visibleItemsCount = 3,
+                        textModifier = Modifier.padding(18.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .alignBy { it.measuredHeight / 2 },
+                        textStyle = Typography.titleSmall.copy(color = black),
+                        dividerColor = point,
+                    )
+
+                    HorizontalSpacer(width = 12.dp)
+
+                    Text(
+                        text = ":",
+                        style = Typography.titleSmall,
+                        color = Color.Black,
+                        modifier = Modifier.alignBy { it.measuredHeight / 2 }
+
+                    )
+
+                    HorizontalSpacer(width = 12.dp)
+
+                    Picker(
+                        state = minutePickerState,
+                        items = minute,
+                        visibleItemsCount = 2,
+                        textModifier = Modifier.padding(18.dp),
+                        modifier = Modifier.weight(1f),
+                        textStyle = Typography.titleSmall.copy(color = black),
+                        dividerColor = point,
+                    )
+                }
+
+                VerticalSpacer(height = 43.dp)
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(end = 24.dp, bottom = 24.dp)
+                ) {
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    TextButton(
+                        onClick = { setShowDialog(false) },
+                    ) {
+                        Text(
+                            text = "취소",
+                            style = Typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                            color = point
+                        )
+                    }
+
+                    HorizontalSpacer(width = 8.dp)
+
+                    TextButton(
+                        onClick = onSaveButtonClick,
+                    ) {
+                        Text(
+                            text = "저장",
+                            style = Typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                            color = point
+                        )
+                    }
+
+
+                }
+
+
+            }
+
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun PreviewSmeemTimePickerDialog() {
+    SmeemTimePickerDialog(
+        setShowDialog = {},
+        onSaveButtonClick = {},
+        onDismissRequest = {}
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
@@ -76,7 +76,7 @@ fun SmeemTimePickerDialog(
                     Picker(
                         state = timeOfDayPickerState,
                         items = timeOfDay,
-                        visibleItemsCount = 2,
+                        visibleItemsCount = 3,
                         textModifier = Modifier.padding(18.dp),
                         modifier = Modifier.weight(1f),
                         textStyle = Typography.titleSmall.copy(color = black),
@@ -112,7 +112,7 @@ fun SmeemTimePickerDialog(
                     Picker(
                         state = minutePickerState,
                         items = minute,
-                        visibleItemsCount = 2,
+                        visibleItemsCount = 3,
                         textModifier = Modifier.padding(18.dp),
                         modifier = Modifier.weight(1f),
                         textStyle = Typography.titleSmall.copy(color = black),
@@ -151,13 +151,8 @@ fun SmeemTimePickerDialog(
                             color = point
                         )
                     }
-
-
                 }
-
-
             }
-
         }
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.sopt.smeem.Smeem
 import com.sopt.smeem.domain.model.Date
 import com.sopt.smeem.domain.repository.DiaryRepository
 import com.sopt.smeem.event.AmplitudeEventType
+import com.sopt.smeem.presentation.home.calendar.core.CalendarState
 import com.sopt.smeem.presentation.home.calendar.core.Period
 import com.sopt.smeem.util.DateUtil
 import com.sopt.smeem.util.getNextDates
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.zip
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.time.LocalDate
 import java.time.YearMonth

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
@@ -3,6 +3,8 @@ package com.sopt.smeem.presentation.mypage
 const val MY_SUMMARY = "MyPage"
 const val SETTING = "Setting"
 const val MORE = "More"
+
+const val SETTING_MAIN = "SettingMain"
 const val CHANGE_NICKNAME = "ChangeNickname"
 
 const val NICKNAME_MIN_LENGTH = 1

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
@@ -6,6 +6,7 @@ const val MORE = "More"
 
 const val SETTING_MAIN = "SettingMain"
 const val CHANGE_NICKNAME = "ChangeNickname"
+const val EDIT_TRAINING_TIME = "EditTrainingTime"
 
 const val NICKNAME_MIN_LENGTH = 1
 const val NICKNAME_MAX_LENGTH = 10

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/StudyNotificationCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/StudyNotificationCard.kt
@@ -1,0 +1,58 @@
+package com.sopt.smeem.presentation.mypage.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
+import com.sopt.smeem.presentation.compose.theme.gray200
+import com.sopt.smeem.presentation.compose.theme.point
+import com.sopt.smeem.presentation.compose.theme.white
+
+@Composable
+fun StudyNotificationCard(
+    modifier: Modifier = Modifier,
+    checked: Boolean = true,
+    onCheckedChange: (Boolean) -> Unit
+) {
+
+    SmeemContents(title = stringResource(id = R.string.my_page_study_alarm)) {
+        SmeemCard(text = stringResource(id = R.string.my_page_training_push_alarm)) {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = white,
+                    checkedTrackColor = point,
+                    uncheckedThumbColor = white,
+                    uncheckedTrackColor = gray200,
+                    uncheckedBorderColor = gray200,
+                ),
+                modifier = modifier
+                    .scale(0.69f)
+                    .padding(end = 20.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun StudyNotificationCardPreview() {
+    StudyNotificationCard(onCheckedChange = {})
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun StudyNotificationCardPreviewUnchecked() {
+    StudyNotificationCard(checked = false, onCheckedChange = {})
+}
+
+
+
+

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
@@ -20,6 +20,7 @@ fun MySummaryScreen(
     navController: NavController,
     modifier: Modifier
 ) {
+
     val mockMySmeem = MySmeem(
         visitDays = 23,
         diaryCount = 19,

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
+import androidx.navigation.navigation
 import com.sopt.smeem.R
 import com.sopt.smeem.presentation.mypage.TempMyPageActivity
 import com.sopt.smeem.presentation.mypage.components.topbar.MySummaryTopAppBar
@@ -47,7 +48,7 @@ fun MyPageNavHost(
                     }
                 )
 
-                MyPageScreen.Setting.route -> SettingTopAppBar(
+                SettingNavGraph.SettingMain.route -> SettingTopAppBar(
                     onNavigationIconClick = { navController.popBackStack() },
                     onMoreClick = {
                         navController.navigate(MyPageScreen.More.route) {
@@ -61,7 +62,7 @@ fun MyPageNavHost(
                     onNavigationIconClick = { navController.popBackStack() }
                 )
 
-                MyPageScreen.ChangeNickname.route -> TitleTopAppbar(
+                SettingNavGraph.ChangeNickname.route -> TitleTopAppbar(
                     onNavigationIconClick = { navController.popBackStack() },
                     title = stringResource(R.string.my_page_change_nickname)
                 )
@@ -72,7 +73,6 @@ fun MyPageNavHost(
             addMySummary(navController = navController, modifier = Modifier.padding(it))
             addSetting(navController = navController, modifier = Modifier.padding(it))
             addMore(navController = navController, modifier = Modifier.padding(it))
-            addChangeNickname(modifier = Modifier.padding(it))
         }
     }
 }
@@ -87,11 +87,28 @@ private fun NavGraphBuilder.addMySummary(navController: NavController, modifier:
 }
 
 private fun NavGraphBuilder.addSetting(navController: NavController, modifier: Modifier) {
-    composable(route = MyPageScreen.Setting.route) {
-        SettingScreen(
-            navController = navController,
-            modifier = modifier
-        )
+    navigation(
+        startDestination = SettingNavGraph.SettingMain.route,
+        route = MyPageScreen.Setting.route
+    ) {
+        composable(route = SettingNavGraph.SettingMain.route) {
+            SettingScreen(
+                navController = navController,
+                modifier = modifier
+            )
+        }
+
+        composable(
+            route = SettingNavGraph.ChangeNickname.route,
+            arguments = listOf(navArgument("nickname") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val nickname = backStackEntry.arguments?.getString("nickname") ?: ""
+
+            ChangeNicknameScreen(
+                modifier = modifier,
+                nickname = nickname
+            )
+        }
     }
 }
 
@@ -104,16 +121,3 @@ private fun NavGraphBuilder.addMore(navController: NavController, modifier: Modi
     }
 }
 
-private fun NavGraphBuilder.addChangeNickname(modifier: Modifier) {
-    composable(
-        route = MyPageScreen.ChangeNickname.route,
-        arguments = listOf(navArgument("nickname") { type = NavType.StringType })
-    ) { backStackEntry ->
-        val nickname = backStackEntry.arguments?.getString("nickname") ?: ""
-
-        ChangeNicknameScreen(
-            modifier = modifier,
-            nickname = nickname
-        )
-    }
-}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -136,7 +136,10 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
                 }
             }
 
-            EditTrainingTimeScreen(trainingTime = trainingTime.value, modifier = modifier)
+            EditTrainingTimeScreen(
+                modifier = modifier,
+                trainingTime = trainingTime.value,
+            )
         }
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -3,7 +3,10 @@ package com.sopt.smeem.presentation.mypage.navigation
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -17,6 +20,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.sopt.smeem.R
+import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.mypage.TempMyPageActivity
 import com.sopt.smeem.presentation.mypage.components.topbar.MySummaryTopAppBar
 import com.sopt.smeem.presentation.mypage.components.topbar.OnlyBackArrowTopAppBar
@@ -25,6 +29,7 @@ import com.sopt.smeem.presentation.mypage.components.topbar.TitleTopAppbar
 import com.sopt.smeem.presentation.mypage.more.MoreScreen
 import com.sopt.smeem.presentation.mypage.mysummary.MySummaryScreen
 import com.sopt.smeem.presentation.mypage.setting.ChangeNicknameScreen
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeScreen
 import com.sopt.smeem.presentation.mypage.setting.SettingScreen
 
 @Composable
@@ -49,7 +54,9 @@ fun MyPageNavHost(
                 )
 
                 SettingNavGraph.SettingMain.route -> SettingTopAppBar(
-                    onNavigationIconClick = { navController.popBackStack() },
+                    onNavigationIconClick = {
+                        navController.popBackStack()
+                    },
                     onMoreClick = {
                         navController.navigate(MyPageScreen.More.route) {
                             launchSingleTop = true
@@ -65,6 +72,11 @@ fun MyPageNavHost(
                 SettingNavGraph.ChangeNickname.route -> TitleTopAppbar(
                     onNavigationIconClick = { navController.popBackStack() },
                     title = stringResource(R.string.my_page_change_nickname)
+                )
+
+                SettingNavGraph.EditTrainingTime.route -> TitleTopAppbar(
+                    onNavigationIconClick = { navController.popBackStack() },
+                    title = stringResource(R.string.edit_traint_time_top_app_bar_title)
                 )
             }
         }
@@ -108,6 +120,23 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
                 modifier = modifier,
                 nickname = nickname
             )
+        }
+
+        composable(
+            route = SettingNavGraph.EditTrainingTime.route,
+        ) {
+            var trainingTime = rememberSaveable { mutableStateOf(TrainingTime(setOf(), 0, 0)) }
+
+            LaunchedEffect(key1 = it) {
+                val result =
+                    navController.previousBackStackEntry?.savedStateHandle?.get<TrainingTime>("trainingTime")
+
+                result?.let {
+                    trainingTime.value = it
+                }
+            }
+
+            EditTrainingTimeScreen(trainingTime = trainingTime.value, modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageScreen.kt
@@ -1,6 +1,5 @@
 package com.sopt.smeem.presentation.mypage.navigation
 
-import com.sopt.smeem.presentation.mypage.CHANGE_NICKNAME
 import com.sopt.smeem.presentation.mypage.MORE
 import com.sopt.smeem.presentation.mypage.MY_SUMMARY
 import com.sopt.smeem.presentation.mypage.SETTING
@@ -9,8 +8,4 @@ sealed class MyPageScreen(val route: String) {
     data object MySummary : MyPageScreen(MY_SUMMARY)
     data object Setting : MyPageScreen(SETTING)
     data object More : MyPageScreen(MORE)
-
-    data object ChangeNickname : MyPageScreen("$CHANGE_NICKNAME/{nickname}") {
-        fun createRoute(nickname: String): String = "$CHANGE_NICKNAME/$nickname"
-    }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
@@ -1,0 +1,12 @@
+package com.sopt.smeem.presentation.mypage.navigation
+
+import com.sopt.smeem.presentation.mypage.CHANGE_NICKNAME
+import com.sopt.smeem.presentation.mypage.SETTING_MAIN
+
+sealed class SettingNavGraph(val route: String) {
+    data object SettingMain : SettingNavGraph(SETTING_MAIN)
+
+    data object ChangeNickname : SettingNavGraph("$CHANGE_NICKNAME/{nickname}") {
+        fun createRoute(nickname: String): String = "$CHANGE_NICKNAME/$nickname"
+    }
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
@@ -1,6 +1,7 @@
 package com.sopt.smeem.presentation.mypage.navigation
 
 import com.sopt.smeem.presentation.mypage.CHANGE_NICKNAME
+import com.sopt.smeem.presentation.mypage.EDIT_TRAINING_TIME
 import com.sopt.smeem.presentation.mypage.SETTING_MAIN
 
 sealed class SettingNavGraph(val route: String) {
@@ -9,4 +10,6 @@ sealed class SettingNavGraph(val route: String) {
     data object ChangeNickname : SettingNavGraph("$CHANGE_NICKNAME/{nickname}") {
         fun createRoute(nickname: String): String = "$CHANGE_NICKNAME/$nickname"
     }
+
+    data object EditTrainingTime : SettingNavGraph(EDIT_TRAINING_TIME)
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -4,34 +4,54 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
+import com.sopt.smeem.presentation.compose.components.SmeemTimePickerDialog
+import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
 fun EditTrainingTimeScreen(
     modifier: Modifier = Modifier,
-    trainingTime: TrainingTime
+    trainingTime: TrainingTime,
 ) {
 
+    var showTimePickDialog by rememberSaveable { mutableStateOf(false) }
+
     Column(modifier = modifier.fillMaxWidth()) {
+
+        VerticalSpacer(height = 24.dp)
+
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),
             isDaySelected = { trainingTime.days.contains(Day.from(it)) },
             trainingTime = "${trainingTime.asHour()}:${trainingTime.asMinute()} ${trainingTime.asAmpm()}",
+            onTimeCardClick = { showTimePickDialog = true },
+            isContentClickable = true
         )
-    }
 
+        if (showTimePickDialog) {
+            SmeemTimePickerDialog(
+                setShowDialog = { showTimePickDialog = it },
+                onDismissRequest = { showTimePickDialog = false },
+                onSaveButtonClick = { showTimePickDialog = false }
+            )
+        }
+    }
 
 }
 
-@Preview
+@Preview(showSystemUi = true, showBackground = true)
 @Composable
 fun PreviewEditTrainingTimeScreen() {
     EditTrainingTimeScreen(
-        trainingTime = TrainingTime(setOf(Day.MON, Day.THU), 10, 30)
+        trainingTime = TrainingTime(setOf(Day.MON, Day.THU), 10, 30),
     )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -1,0 +1,37 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.domain.model.Day
+import com.sopt.smeem.domain.model.TrainingTime
+import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
+
+@Composable
+fun EditTrainingTimeScreen(
+    modifier: Modifier = Modifier,
+    trainingTime: TrainingTime
+) {
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        SmeemAlarmCard(
+            modifier = Modifier.padding(horizontal = 19.dp),
+            isDaySelected = { trainingTime.days.contains(Day.from(it)) },
+            trainingTime = "${trainingTime.asHour()}:${trainingTime.asMinute()} ${trainingTime.asAmpm()}",
+        )
+    }
+
+
+}
+
+@Preview
+@Composable
+fun PreviewEditTrainingTimeScreen() {
+    EditTrainingTimeScreen(
+        trainingTime = TrainingTime(setOf(Day.MON, Day.THU), 10, 30)
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -1,6 +1,7 @@
 package com.sopt.smeem.presentation.mypage.setting
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -9,11 +10,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
+import com.sopt.smeem.presentation.compose.components.SmeemButton
 import com.sopt.smeem.presentation.compose.components.SmeemTimePickerDialog
 import com.sopt.smeem.util.VerticalSpacer
 
@@ -37,13 +41,27 @@ fun EditTrainingTimeScreen(
             isContentClickable = true
         )
 
-        if (showTimePickDialog) {
-            SmeemTimePickerDialog(
-                setShowDialog = { showTimePickDialog = it },
-                onDismissRequest = { showTimePickDialog = false },
-                onSaveButtonClick = { showTimePickDialog = false }
-            )
-        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+
+        SmeemButton(
+            text = stringResource(R.string.training_time_change_button),
+            onClick = { /*TODO*/ },
+            modifier = Modifier.padding(horizontal = 18.dp),
+            isButtonEnabled = true
+        )
+
+        VerticalSpacer(height = 10.dp)
+
+    }
+
+    if (showTimePickDialog) {
+        SmeemTimePickerDialog(
+            setShowDialog = { showTimePickDialog = it },
+            onDismissRequest = { showTimePickDialog = false },
+            onSaveButtonClick = { }
+        )
     }
 
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -19,7 +20,7 @@ import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
 import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
 import com.sopt.smeem.presentation.mypage.components.TargetLanguageCard
-import com.sopt.smeem.presentation.mypage.navigation.MyPageScreen
+import com.sopt.smeem.presentation.mypage.navigation.SettingNavGraph
 import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
@@ -27,6 +28,8 @@ fun SettingScreen(
     navController: NavController,
     modifier: Modifier
 ) {
+    val context = LocalContext.current
+
     val mockNickname = "이태하이"
     val mockMyPlan = "주 3회 일기 작성하기"
 
@@ -43,7 +46,7 @@ fun SettingScreen(
         ChangeNicknameCard(
             nickname = mockNickname,
             onEditClick = {
-                navController.navigate(MyPageScreen.ChangeNickname.createRoute(mockNickname))
+                navController.navigate(SettingNavGraph.ChangeNickname.createRoute(mockNickname))
             }
         )
 
@@ -69,7 +72,12 @@ fun SettingScreen(
 
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),
-            isDaySelected = { mockDays.contains(it) }
+            isDaySelected = { mockDays.contains(it) },
+            onClick = {
+                if (isSwitchChecked) {
+//                    context.startActivity(Intent(context, EditTrainingTimeActivity::class.java))
+                }
+            }
         )
     }
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -3,6 +3,10 @@ package com.sopt.smeem.presentation.mypage.setting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -11,6 +15,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
+import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
 import com.sopt.smeem.presentation.mypage.components.TargetLanguageCard
 import com.sopt.smeem.presentation.mypage.navigation.MyPageScreen
 import com.sopt.smeem.util.VerticalSpacer
@@ -22,6 +27,9 @@ fun SettingScreen(
 ) {
     val mockNickname = "이태하이"
     val mockMyPlan = "주 3회 일기 작성하기"
+
+    // TODO 초기값 서버에서 가져오기
+    var isSwitchChecked by rememberSaveable { mutableStateOf(true) }
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -43,6 +51,13 @@ fun SettingScreen(
         VerticalSpacer(height = 28.dp)
 
         TargetLanguageCard(onEditClick = {})
+
+        VerticalSpacer(height = 28.dp)
+
+        StudyNotificationCard(
+            checked = isSwitchChecked,
+            onCheckedChange = { isSwitchChecked = it }
+        )
     }
 }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -65,7 +65,7 @@ fun SettingScreen(
             }
         )
 
-        VerticalSpacer(height = 28.dp)
+        VerticalSpacer(height = 10.dp)
 
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import com.sopt.smeem.presentation.compose.components.SmeemAlarmDays
+import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
 import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
@@ -32,6 +32,7 @@ fun SettingScreen(
 
     // TODO 초기값 서버에서 가져오기
     var isSwitchChecked by rememberSaveable { mutableStateOf(true) }
+    val mockDays = setOf("월", "화", "수", "목", "금")
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -66,7 +67,10 @@ fun SettingScreen(
 
         VerticalSpacer(height = 28.dp)
 
-        SmeemAlarmDays(modifier = Modifier.padding(horizontal = 19.dp))
+        SmeemAlarmCard(
+            modifier = Modifier.padding(horizontal = 19.dp),
+            isDaySelected = { mockDays.contains(it) }
+        )
     }
 }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -2,6 +2,7 @@ package com.sopt.smeem.presentation.mypage.setting
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.sopt.smeem.presentation.compose.components.SmeemAlarmDays
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
 import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
@@ -56,8 +58,15 @@ fun SettingScreen(
 
         StudyNotificationCard(
             checked = isSwitchChecked,
-            onCheckedChange = { isSwitchChecked = it }
+            onCheckedChange = {
+                isSwitchChecked = it
+                // TODO if 문으로 뷰모델의 changePushAlarm 호출
+            }
         )
+
+        VerticalSpacer(height = 28.dp)
+
+        SmeemAlarmDays(modifier = Modifier.padding(horizontal = 19.dp))
     }
 }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -10,11 +10,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.sopt.smeem.domain.model.Day
+import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
@@ -28,14 +29,13 @@ fun SettingScreen(
     navController: NavController,
     modifier: Modifier
 ) {
-    val context = LocalContext.current
-
-    val mockNickname = "이태하이"
-    val mockMyPlan = "주 3회 일기 작성하기"
 
     // TODO 초기값 서버에서 가져오기
+    val mockNickname = "이태하이"
+    val mockMyPlan = "주 3회 일기 작성하기"
     var isSwitchChecked by rememberSaveable { mutableStateOf(true) }
-    val mockDays = setOf("월", "화", "수", "목", "금")
+    val mockDays = setOf(Day.MON, Day.TUE, Day.THU)
+    val mockTrainingTime = TrainingTime(mockDays, 12, 30)
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -72,10 +72,17 @@ fun SettingScreen(
 
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),
-            isDaySelected = { mockDays.contains(it) },
-            onClick = {
+            isDaySelected = { mockTrainingTime.days.contains(Day.from(it)) },
+            onAlarmCardClick = {
                 if (isSwitchChecked) {
-//                    context.startActivity(Intent(context, EditTrainingTimeActivity::class.java))
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        "trainingTime",
+                        mockTrainingTime
+                    )
+
+                    navController.navigate(
+                        SettingNavGraph.EditTrainingTime.route
+                    )
                 }
             }
         )

--- a/app/src/main/java/com/sopt/smeem/util/BorderExt.kt
+++ b/app/src/main/java/com/sopt/smeem/util/BorderExt.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.presentation.compose.theme.gray200
 
 data class Border(val strokeWidth: Dp, val color: Color)
 
@@ -16,6 +19,10 @@ fun Modifier.sideBorder(
     top: Border? = null,
     end: Border? = null,
     bottom: Border? = null,
+    topEnd: Border? = null,
+    topStart: Border? = null,
+    bottomStart: Border? = null,
+    bottomEnd: Border? = null
 ) =
     drawBehind {
         start?.let {
@@ -29,6 +36,34 @@ fun Modifier.sideBorder(
         }
         bottom?.let {
             drawBottomBorder(border = it, shareStart = start != null, shareEnd = end != null)
+        }
+        topStart?.let {
+            drawTopStartBorderWithRoundCorner(
+                startBorder = start ?: Border(1.dp, gray200),
+                topBorder = top ?: Border(1.dp, gray200),
+                roundCornerSize = 6.dp
+            )
+        }
+        topEnd?.let {
+            drawTopAndEndBorderWithRoundCorner(
+                topBorder = top ?: Border(1.dp, gray200),
+                endBorder = end ?: Border(1.dp, gray200),
+                roundCornerSize = 6.dp
+            )
+        }
+        bottomStart?.let {
+            drawBottomStartBorderWithRoundCorner(
+                startBorder = start ?: Border(1.dp, gray200),
+                bottomBorder = bottom ?: Border(1.dp, gray200),
+                roundCornerSize = 6.dp
+            )
+        }
+        bottomEnd?.let {
+            drawBottomEndBorderWithRoundCorner(
+                endBorder = end ?: Border(1.dp, gray200),
+                bottomBorder = bottom ?: Border(1.dp, gray200),
+                roundCornerSize = 6.dp
+            )
         }
     }
 
@@ -113,3 +148,156 @@ private fun DrawScope.drawEndBorder(
         color = border.color
     )
 }
+
+private fun DrawScope.drawTopStartBorderWithRoundCorner(
+    startBorder: Border,
+    topBorder: Border,
+    roundCornerSize: Dp = 6.dp
+) {
+    val topStrokeWidthPx = topBorder.strokeWidth.toPx() * 2
+    val startStrokeWidthPx = startBorder.strokeWidth.toPx() * 2
+    if (topStrokeWidthPx == 0f || startStrokeWidthPx == 0f) return
+
+    val cornerRadiusPx = roundCornerSize.toPx()
+    val width = size.width
+    val height = size.height
+
+    // 상단 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(0f, cornerRadiusPx)
+            quadraticBezierTo(
+                x1 = 0f, y1 = 0f,
+                x2 = cornerRadiusPx, y2 = 0f
+            )
+            lineTo(width, 0f)
+        },
+        color = topBorder.color,
+        style = Stroke(width = topStrokeWidthPx)
+    )
+
+    // 왼쪽 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(0f, cornerRadiusPx)
+            lineTo(0f, height)
+        },
+        color = startBorder.color,
+        style = Stroke(width = startStrokeWidthPx)
+    )
+}
+
+private fun DrawScope.drawTopAndEndBorderWithRoundCorner(
+    topBorder: Border,
+    endBorder: Border,
+    roundCornerSize: Dp = 6.dp
+) {
+    val topStrokeWidthPx = topBorder.strokeWidth.toPx() * 2
+    val endStrokeWidthPx = endBorder.strokeWidth.toPx() * 2
+    if (topStrokeWidthPx == 0f || endStrokeWidthPx == 0f) return
+
+    val cornerRadiusPx = roundCornerSize.toPx()
+    val width = size.width
+    val height = size.height
+
+    // 상단 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(0f, 0f)
+            lineTo(width - cornerRadiusPx, 0f) // 둥근 모서리 시작 직전까지 선 그리기
+            quadraticBezierTo(
+                x1 = width, y1 = 0f,
+                x2 = width, y2 = cornerRadiusPx
+            ) // 둥근 모서리 그리기
+        },
+        color = topBorder.color,
+        style = Stroke(width = topStrokeWidthPx)
+    )
+
+    // 우측 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(width, cornerRadiusPx) // 둥근 모서리가 끝난 지점부터 시작
+            lineTo(width, height) // 하단까지 선 그리기
+        },
+        color = endBorder.color,
+        style = Stroke(width = endStrokeWidthPx)
+    )
+}
+
+private fun DrawScope.drawBottomStartBorderWithRoundCorner(
+    startBorder: Border,
+    bottomBorder: Border,
+    roundCornerSize: Dp = 6.dp
+) {
+    val bottomStrokeWidthPx = bottomBorder.strokeWidth.toPx() * 2
+    val startStrokeWidthPx = startBorder.strokeWidth.toPx() * 2
+    if (bottomStrokeWidthPx == 0f || startStrokeWidthPx == 0f) return
+
+    val cornerRadiusPx = roundCornerSize.toPx()
+    val width = size.width
+
+    // 하단 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(0f, size.height - cornerRadiusPx)
+            quadraticBezierTo(
+                x1 = 0f, y1 = size.height,
+                x2 = cornerRadiusPx, y2 = size.height
+            )
+            lineTo(width, size.height)
+        },
+        color = bottomBorder.color,
+        style = Stroke(width = bottomStrokeWidthPx)
+    )
+
+    // 왼쪽 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(0f, 0f)
+            lineTo(0f, size.height - cornerRadiusPx)
+        },
+        color = startBorder.color,
+        style = Stroke(width = startStrokeWidthPx)
+    )
+}
+
+private fun DrawScope.drawBottomEndBorderWithRoundCorner(
+    endBorder: Border,
+    bottomBorder: Border,
+    roundCornerSize: Dp = 6.dp
+) {
+    val bottomStrokeWidthPx = bottomBorder.strokeWidth.toPx() * 2
+    val endStrokeWidthPx = endBorder.strokeWidth.toPx() * 2
+    if (bottomStrokeWidthPx == 0f || endStrokeWidthPx == 0f) return
+
+    val cornerRadiusPx = roundCornerSize.toPx()
+    val width = size.width
+    val height = size.height
+
+    // 하단 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(width - cornerRadiusPx, height)
+            quadraticBezierTo(
+                x1 = width, y1 = height,
+                x2 = width, y2 = height - cornerRadiusPx
+            ) // 둥근 모서리 그리기
+            lineTo(width, 0f)
+        },
+        color = bottomBorder.color,
+        style = Stroke(width = bottomStrokeWidthPx)
+    )
+
+    // 우측 테두리 그리기
+    drawPath(
+        path = Path().apply {
+            moveTo(width, height - cornerRadiusPx) // 둥근 모서리가 끝난 지점부터 시작
+            lineTo(width, 0f) // 상단까지 선 그리기
+        },
+        color = endBorder.color,
+        style = Stroke(width = endStrokeWidthPx)
+    )
+}
+
+

--- a/app/src/main/java/com/sopt/smeem/util/BorderExt.kt
+++ b/app/src/main/java/com/sopt/smeem/util/BorderExt.kt
@@ -1,0 +1,115 @@
+package com.sopt.smeem.util
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Dp
+
+data class Border(val strokeWidth: Dp, val color: Color)
+
+@Stable
+fun Modifier.sideBorder(
+    start: Border? = null,
+    top: Border? = null,
+    end: Border? = null,
+    bottom: Border? = null,
+) =
+    drawBehind {
+        start?.let {
+            drawStartBorder(it, shareTop = top != null, shareBottom = bottom != null)
+        }
+        top?.let {
+            drawTopBorder(it, shareStart = start != null, shareEnd = end != null)
+        }
+        end?.let {
+            drawEndBorder(it, shareTop = top != null, shareBottom = bottom != null)
+        }
+        bottom?.let {
+            drawBottomBorder(border = it, shareStart = start != null, shareEnd = end != null)
+        }
+    }
+
+private fun DrawScope.drawTopBorder(
+    border: Border,
+    shareStart: Boolean = true,
+    shareEnd: Boolean = true
+) {
+    val strokeWidthPx = border.strokeWidth.toPx()
+    if (strokeWidthPx == 0f) return
+    drawPath(
+        Path().apply {
+            moveTo(0f, 0f)
+            lineTo(if (shareStart) strokeWidthPx else 0f, strokeWidthPx)
+            val width = size.width
+            lineTo(if (shareEnd) width - strokeWidthPx else width, strokeWidthPx)
+            lineTo(width, 0f)
+            close()
+        },
+        color = border.color
+    )
+}
+
+private fun DrawScope.drawBottomBorder(
+    border: Border,
+    shareStart: Boolean,
+    shareEnd: Boolean
+) {
+    val strokeWidthPx = border.strokeWidth.toPx()
+    if (strokeWidthPx == 0f) return
+    drawPath(
+        Path().apply {
+            val width = size.width
+            val height = size.height
+            moveTo(0f, height)
+            lineTo(if (shareStart) strokeWidthPx else 0f, height - strokeWidthPx)
+            lineTo(if (shareEnd) width - strokeWidthPx else width, height - strokeWidthPx)
+            lineTo(width, height)
+            close()
+        },
+        color = border.color
+    )
+}
+
+private fun DrawScope.drawStartBorder(
+    border: Border,
+    shareTop: Boolean = true,
+    shareBottom: Boolean = true
+) {
+    val strokeWidthPx = border.strokeWidth.toPx()
+    if (strokeWidthPx == 0f) return
+    drawPath(
+        Path().apply {
+            moveTo(0f, 0f)
+            lineTo(strokeWidthPx, if (shareTop) strokeWidthPx else 0f)
+            val height = size.height
+            lineTo(strokeWidthPx, if (shareBottom) height - strokeWidthPx else height)
+            lineTo(0f, height)
+            close()
+        },
+        color = border.color
+    )
+}
+
+private fun DrawScope.drawEndBorder(
+    border: Border,
+    shareTop: Boolean = true,
+    shareBottom: Boolean = true
+) {
+    val strokeWidthPx = border.strokeWidth.toPx()
+    if (strokeWidthPx == 0f) return
+    drawPath(
+        Path().apply {
+            val width = size.width
+            val height = size.height
+            moveTo(width, 0f)
+            lineTo(width - strokeWidthPx, if (shareTop) strokeWidthPx else 0f)
+            lineTo(width - strokeWidthPx, if (shareBottom) height - strokeWidthPx else height)
+            lineTo(width, height)
+            close()
+        },
+        color = border.color
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/util/ContextExtension.kt
+++ b/app/src/main/java/com/sopt/smeem/util/ContextExtension.kt
@@ -1,4 +1,4 @@
-package com.sopt.smeem
+package com.sopt.smeem.util
 
 import android.content.Context
 

--- a/app/src/main/res/layout/activity_my_page.xml
+++ b/app/src/main/res/layout/activity_my_page.xml
@@ -357,7 +357,7 @@
                     android:layout_height="0dp"
 
                     android:layout_marginTop="52dp"
-                    android:text="@string/my_page_alarm"
+                    android:text="@string/my_page_study_alarm"
                     android:textAppearance="@style/TextAppearance.Smeem.Subtitle1_bold"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/layout_my_page_language" />
@@ -378,7 +378,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="2dp"
-                        android:text="@string/my_page_push"
+                        android:text="@string/my_page_training_push_alarm"
                         android:textAppearance="@style/TextAppearance.Smeem.Body4_regular"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,5 @@
     <!-- Training Time -->
     <string name="default_training_time">10:00 PM</string>
     <string name="my_page_setting_training_time_title">알림 시간</string>
+    <string name="edit_traint_time_top_app_bar_title">학습 알림 설정</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,4 +107,5 @@
     <string name="default_training_time">10:00 PM</string>
     <string name="my_page_setting_training_time_title">알림 시간</string>
     <string name="edit_traint_time_top_app_bar_title">학습 알림 설정</string>
+    <string name="training_time_change_button">완료</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,8 @@
     <string name="smeem_dialog_logout_content">로그아웃 하시겠습니까?</string>
     <string name="smeem_dialog_delete_account_title">계정을 삭제하시겠습니까?</string>
     <string name="smeem_dialog_delete_dialog_content">이전에 작성했던 일기는 모두 사라집니다.</string>
+
+    <!-- Training Time -->
+    <string name="default_training_time">10:00 PM</string>
+    <string name="my_page_setting_training_time_title">알림 시간</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,6 @@
     <string name="entrance_agreement_location">[필수] 위치기반 서비스 이용약관 동의</string>
     <string name="entrance_agreement_marketing">[선택] 마케팅 정보 활용 동의</string>
     <string name="my_page_badges">내 배지</string>
-    <string name="my_page_push">트레이닝 푸시알림</string>
     <string name="my_page_edit_done_message">변경 완료</string>
     <string name="diary_write_next">다음</string>
     <string name="diary_write_done">완료</string>
@@ -81,10 +80,11 @@
     <string name="smeem_card_edit">수정하기</string>
     <string name="change_nickname_card">닉네임 변경</string>
     <string name="my_page_languages">학습 언어</string>
-    <string name="my_page_alarm">학습 알림</string>
+    <string name="my_page_study_alarm">학습 알림</string>
     <string name="language_english">English</string>
     <string name="edit_target_language">edit target language</string>
-    
+    <string name="my_page_training_push_alarm">트레이닝 푸시알림</string>
+
     <string name="my_page_change_nickname">닉네임 변경</string>
     <string name="my_page_change_nickname_button">완료</string>
 


### PR DESCRIPTION
- closed #250 
- closed #254 

## *⛳️ Work Description*
- switch 구현 (추후 뷰모델과 연결하고 pushAlarm 함수 연동해야함, 기존 얼리기 녹이기 작업할 예정)
- 커스텀 border를 적용해서 트레이닝 날짜 뷰 구현
- SettingNavGraph 분리
- parcelable 데이터 넘겨서 EditTrainingScreen으로 이동
- 커스텀 Picker 구현 -> 시간 설정 다이얼로그 구현

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/Team-Smeme/smeem-aos/assets/98825364/7bb0bf8b-7277-4ca0-997c-15af8b18f12a


## *📢 To Reviewers*
- 트레이닝 날짜 누를 때 색 변하는 로직은 뷰모델과 연결 후 해야되므로 다른 브렌치에서 작업하겠습니다
- 뷰모델과 연동하면 코드가 많이 바뀔거에요, 일단 뷰만 그렸습니다
- 기기대응도 다 했습니다.
- 이쪽 부분 기존 뷰모델에 있는 코드 어느정도 가공해서 새로 뷰모델 만든다음에 연동작업까지 제가 하겠습니다.
- HomeViewModel import 에러 여기서 수정해서 push 했어요

