### PR TITLE
[마이페이지] 트레이닝 플랜 변경 화면 구현

### DIFF
--- a/app/src/main/java/com/sopt/smeem/domain/model/mypage/TrainingPlan.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/model/mypage/TrainingPlan.kt
@@ -1,0 +1,13 @@
+package com.sopt.smeem.domain.model.mypage
+
+data class TrainingPlan(
+    val id: Int,
+    val content: String
+)
+
+enum class TrainingPlanDescription(val id: Int, val description: String) {
+    ONCE_A_WEEK(1, "주 1회 작성할게요"),
+    TWICE_A_WEEK(2, "주 3회 작성할게요"),
+    THREE_TIMES_A_WEEK(3, "주 5회 작성할게요"),
+    DAILY(4, "매일 작성할게요")
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/Const.kt
@@ -6,6 +6,7 @@ const val MORE = "More"
 
 const val SETTING_MAIN = "SettingMain"
 const val CHANGE_NICKNAME = "ChangeNickname"
+const val EDIT_TRAINING_PLAN = "EditTrainingPlan"
 const val EDIT_TRAINING_TIME = "EditTrainingTime"
 
 const val NICKNAME_MIN_LENGTH = 1

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
@@ -1,0 +1,93 @@
+package com.sopt.smeem.presentation.mypage.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
+import com.sopt.smeem.domain.model.mypage.TrainingPlanDescription
+import com.sopt.smeem.presentation.compose.theme.Typography
+import com.sopt.smeem.presentation.compose.theme.gray100
+import com.sopt.smeem.presentation.compose.theme.gray600
+import com.sopt.smeem.presentation.compose.theme.point
+import com.sopt.smeem.presentation.compose.theme.white
+import com.sopt.smeem.util.HorizontalSpacer
+
+@Composable
+fun TrainingPlanCard(
+    isSelected: Boolean = false,
+    planId: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    val textColor = if (isSelected) point else gray600
+    val textStyle = if (isSelected) Typography.bodySmall else Typography.bodyMedium
+    val planDescription = TrainingPlanDescription.entries.firstOrNull { it.id == planId } ?: return
+    val borderColor = if (isSelected) point else gray100
+    val iconVector =
+        if (isSelected) ImageVector.vectorResource(id = R.drawable.ic_selection_active)
+        else ImageVector.vectorResource(id = R.drawable.ic_selection_inactive)
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .clickable { onClick() },
+        shape = RoundedCornerShape(6.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = white,
+        ),
+        border = BorderStroke(1.5.dp, borderColor)
+    ) {
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 13.dp)
+        ) {
+            Icon(
+                imageVector = iconVector,
+                contentDescription = stringResource(R.string.training_plan_selection_icon),
+                modifier = Modifier.padding(top = 21.dp, bottom = 19.dp)
+            )
+
+            HorizontalSpacer(width = 12.dp)
+
+            Text(
+                text = planDescription.description,
+                style = textStyle,
+                color = textColor,
+                modifier = Modifier.padding(top = 21.dp, bottom = 20.dp)
+            )
+        }
+
+    }
+}
+
+@Preview(showSystemUi = true, showBackground = true)
+@Composable
+fun TrainingPlanUnSelectedCardPreview() {
+    TrainingPlanCard(planId = 1, onClick = {})
+}
+
+@Preview(showSystemUi = true, showBackground = true)
+@Composable
+fun TrainingPlanSelectedCardPreview() {
+    TrainingPlanCard(planId = 1, isSelected = true, onClick = {})
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -64,6 +65,7 @@ fun TrainingPlanCard(
             Icon(
                 imageVector = iconVector,
                 contentDescription = stringResource(R.string.training_plan_selection_icon),
+                tint = Color.Unspecified,
                 modifier = Modifier.padding(top = 21.dp, bottom = 19.dp)
             )
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/TrainingPlanCard.kt
@@ -2,15 +2,18 @@ package com.sopt.smeem.presentation.mypage.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -25,6 +28,7 @@ import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.gray100
 import com.sopt.smeem.presentation.compose.theme.gray600
 import com.sopt.smeem.presentation.compose.theme.point
+import com.sopt.smeem.presentation.compose.theme.pointInactive
 import com.sopt.smeem.presentation.compose.theme.white
 import com.sopt.smeem.util.HorizontalSpacer
 
@@ -49,7 +53,11 @@ fun TrainingPlanCard(
             .fillMaxWidth()
             .padding(horizontal = 18.dp)
             .clip(RoundedCornerShape(6.dp))
-            .clickable { onClick() },
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(color = pointInactive),
+                onClick = onClick,
+            ),
         shape = RoundedCornerShape(6.dp),
         colors = CardDefaults.cardColors(
             containerColor = white,

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -29,6 +29,7 @@ import com.sopt.smeem.presentation.mypage.components.topbar.TitleTopAppbar
 import com.sopt.smeem.presentation.mypage.more.MoreScreen
 import com.sopt.smeem.presentation.mypage.mysummary.MySummaryScreen
 import com.sopt.smeem.presentation.mypage.setting.ChangeNicknameScreen
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingPlanScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeScreen
 import com.sopt.smeem.presentation.mypage.setting.SettingScreen
 
@@ -72,6 +73,11 @@ fun MyPageNavHost(
                 SettingNavGraph.ChangeNickname.route -> TitleTopAppbar(
                     onNavigationIconClick = { navController.popBackStack() },
                     title = stringResource(R.string.my_page_change_nickname)
+                )
+
+                SettingNavGraph.EditTrainingPlan.route -> TitleTopAppbar(
+                    onNavigationIconClick = { navController.popBackStack() },
+                    title = stringResource(R.string.edit_training_plan_title)
                 )
 
                 SettingNavGraph.EditTrainingTime.route -> TitleTopAppbar(
@@ -120,6 +126,12 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
                 modifier = modifier,
                 nickname = nickname
             )
+        }
+
+        composable(
+            route = SettingNavGraph.EditTrainingPlan.route
+        ) {
+            EditTrainingPlanScreen(modifier = modifier)
         }
 
         composable(

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/SettingNavGraph.kt
@@ -1,6 +1,7 @@
 package com.sopt.smeem.presentation.mypage.navigation
 
 import com.sopt.smeem.presentation.mypage.CHANGE_NICKNAME
+import com.sopt.smeem.presentation.mypage.EDIT_TRAINING_PLAN
 import com.sopt.smeem.presentation.mypage.EDIT_TRAINING_TIME
 import com.sopt.smeem.presentation.mypage.SETTING_MAIN
 
@@ -10,6 +11,8 @@ sealed class SettingNavGraph(val route: String) {
     data object ChangeNickname : SettingNavGraph("$CHANGE_NICKNAME/{nickname}") {
         fun createRoute(nickname: String): String = "$CHANGE_NICKNAME/$nickname"
     }
+
+    data object EditTrainingPlan : SettingNavGraph(EDIT_TRAINING_PLAN)
 
     data object EditTrainingTime : SettingNavGraph(EDIT_TRAINING_TIME)
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingPlanScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingPlanScreen.kt
@@ -1,11 +1,66 @@
 package com.sopt.smeem.presentation.mypage.setting
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
+import com.sopt.smeem.presentation.compose.components.SmeemButton
+import com.sopt.smeem.presentation.mypage.components.TrainingPlanCard
+import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
 fun EditTrainingPlanScreen(
     modifier: Modifier = Modifier,
 ) {
+    var selectedItemId by rememberSaveable { mutableIntStateOf(0) }
 
+    Column(modifier = modifier.fillMaxSize()) {
+        VerticalSpacer(height = 24.dp)
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(4) { index ->
+                val itemId = index + 1
+
+                TrainingPlanCard(
+                    isSelected = selectedItemId == itemId,
+                    planId = itemId,
+                    onClick = { selectedItemId = itemId },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        SmeemButton(
+            text = stringResource(id = R.string.edit_training_plan_button),
+            onClick = { /*TODO*/ },
+            modifier = Modifier.padding(horizontal = 18.dp),
+            isButtonEnabled = selectedItemId != 0
+        )
+
+        VerticalSpacer(height = 10.dp)
+
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun EditTrainingPlanScreenPreview() {
+    EditTrainingPlanScreen()
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingPlanScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingPlanScreen.kt
@@ -1,0 +1,11 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EditTrainingPlanScreen(
+    modifier: Modifier = Modifier,
+) {
+
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -52,7 +52,9 @@ fun SettingScreen(
 
         VerticalSpacer(height = 28.dp)
 
-        ChangeMyPlanCard(myPlan = mockMyPlan, onEditClick = {})
+        ChangeMyPlanCard(myPlan = mockMyPlan, onEditClick = {
+            navController.navigate(SettingNavGraph.EditTrainingPlan.route)
+        })
 
         VerticalSpacer(height = 28.dp)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,4 +108,7 @@
     <string name="my_page_setting_training_time_title">알림 시간</string>
     <string name="edit_traint_time_top_app_bar_title">학습 알림 설정</string>
     <string name="training_time_change_button">완료</string>
+
+    <!-- Training Plan -->
+    <string name="edit_training_plan_title">트레이닝 플랜 변경</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,5 @@
 
     <!-- Training Plan -->
     <string name="edit_training_plan_title">트레이닝 플랜 변경</string>
+    <string name="training_plan_selection_icon">selection icon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,4 +112,5 @@
     <!-- Training Plan -->
     <string name="edit_training_plan_title">트레이닝 플랜 변경</string>
     <string name="training_plan_selection_icon">selection icon</string>
+    <string name="edit_training_plan_button">완료</string>
 </resources>


### PR DESCRIPTION
- closed #254 

## *⛳️ Work Description*
- 트레이닝 플랜 변경 화면 구현 
- 트레이닝 플랜 id 받아서 적절한 값들 렌더링 했슴다
- 버튼 활성화 로직도 반영했습니다

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/Team-Smeme/smeem-aos/assets/98825364/739a4f29-de4d-496a-9434-e4c74a91e47c


## *📢 To Reviewers*
- 리플 효과는 디자인 쌤 컨펌 받고 고칠 예정
- 완료 시 서버통신은 다른 브렌치에서 작업 예정
