### PR TITLE
[마이페이지] 성과요약 뷰 서버 연결 (배지 목록 제외)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -220,6 +220,9 @@ dependencies {
     // Optional - Integration with ViewModels
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    // Orbit
+    implementation(libs.bundles.orbit)
+
     // Compose test
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)

--- a/app/src/main/java/com/sopt/smeem/data/usecase/MySummaryUseCase.kt
+++ b/app/src/main/java/com/sopt/smeem/data/usecase/MySummaryUseCase.kt
@@ -1,0 +1,27 @@
+package com.sopt.smeem.data.usecase
+
+import com.sopt.smeem.domain.dto.MyPlanDto
+import com.sopt.smeem.domain.dto.MySmeemDataDto
+import com.sopt.smeem.domain.repository.UserRepository
+import kotlinx.coroutines.coroutineScope
+import javax.inject.Inject
+
+class MySummaryUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+
+    // TODO : 배지까지 반영 -> 주석 해제
+//    suspend operator fun invoke(): Triple<MySmeemDataDto, MyPlanDto?, List<GetBadgeListDto>> =
+//        coroutineScope {
+//            val smeemData = userRepository.getMySmeemData().data()
+//            val myPlan = userRepository.getMyPlanData().data()
+//            val badgeList = userRepository.getMyBadges().data()
+//            Triple(smeemData, myPlan, badgeList)
+//        }
+
+    suspend operator fun invoke(): Pair<MySmeemDataDto, MyPlanDto?> = coroutineScope {
+        val smeemData = userRepository.getMySmeemData().data()
+        val myPlan = userRepository.getMyPlanData().data()
+        Pair(smeemData, myPlan)
+    }
+}

--- a/app/src/main/java/com/sopt/smeem/domain/model/mypage/MyPlan.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/model/mypage/MyPlan.kt
@@ -1,8 +1,0 @@
-package com.sopt.smeem.domain.model.mypage
-
-data class MyPlan(
-    val plan: String,
-    val goal: String,
-    val clearedCount: Int,
-    val clearCount: Int
-)

--- a/app/src/main/java/com/sopt/smeem/domain/model/mypage/MySmeem.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/model/mypage/MySmeem.kt
@@ -1,8 +1,0 @@
-package com.sopt.smeem.domain.model.mypage
-
-data class MySmeem(
-    val visitDays: Int,
-    val diaryCount: Int,
-    val diaryComboCount: Int,
-    val badgeCount: Int
-)

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/LoadingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/LoadingScreen.kt
@@ -1,0 +1,20 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingScreen(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/MyPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/MyPlanCard.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sopt.smeem.R
-import com.sopt.smeem.domain.model.mypage.MyPlan
+import com.sopt.smeem.domain.dto.MyPlanDto
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.black
 import com.sopt.smeem.presentation.compose.theme.gray100
@@ -35,7 +35,7 @@ import com.sopt.smeem.util.dashedBorder
 @Composable
 fun MyPlanCard(
     modifier: Modifier = Modifier,
-    myPlan: MyPlan?
+    myPlan: MyPlanDto?
 ) {
     SmeemContents(
         modifier = modifier,
@@ -152,7 +152,7 @@ fun MyPlanNotClearedDotPreview() {
 @Composable
 fun MyPlanCardPreview() {
     MyPlanCard(
-        myPlan = MyPlan(
+        myPlan = MyPlanDto(
             plan = "매일 일기 작성하기",
             goal = "유창한 비즈니스 영어",
             clearedCount = 3,

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/MySmeemCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/MySmeemCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sopt.smeem.R
-import com.sopt.smeem.domain.model.mypage.MySmeem
+import com.sopt.smeem.domain.dto.MySmeemDataDto
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.black
 import com.sopt.smeem.presentation.compose.theme.gray100
@@ -27,7 +27,7 @@ import com.sopt.smeem.util.VerticalSpacer
 @Composable
 fun MySmeemCard(
     modifier: Modifier = Modifier,
-    mySmeem: MySmeem
+    mySmeem: MySmeemDataDto
 ) {
     SmeemContents(
         modifier = modifier,
@@ -103,7 +103,7 @@ fun MySmeemContentPreview() {
 @Composable
 fun MySmeemPreview() {
     MySmeemCard(
-        mySmeem = MySmeem(
+        mySmeem = MySmeemDataDto(
             visitDays = 23,
             diaryCount = 19,
             diaryComboCount = 3,

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
@@ -26,79 +26,66 @@ import com.sopt.smeem.domain.model.mypage.MySmeem
 import com.sopt.smeem.presentation.compose.theme.SmeemTheme
 import com.sopt.smeem.presentation.mypage.components.MyBadgesBottomSheet
 import com.sopt.smeem.presentation.mypage.components.MyBadgesContent
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.smeem.presentation.compose.components.LoadingScreen
 import com.sopt.smeem.presentation.mypage.components.MyPlanCard
 import com.sopt.smeem.presentation.mypage.components.MySmeemCard
 import com.sopt.smeem.util.VerticalSpacer
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MySummaryScreen(
-    navController: NavController,
+    viewModel: MySummaryViewModel,
     modifier: Modifier
 ) {
+    val state by viewModel.collectAsState()
 
-    val mockMySmeem = MySmeem(
-        visitDays = 23,
-        diaryCount = 19,
-        diaryComboCount = 3,
-        badgeCount = 10
-    )
+    when (val uiState = state.uiState) {
+        is MySummaryUiState.Loading -> {
+            LoadingScreen()
+        }
 
-    val mockMyPlan = MyPlan(
-        plan = "매일 일기 작성하기",
-        goal = "유창한 비즈니스 영어",
-        clearedCount = 2,
-        clearCount = 7
-    )
+        is MySummaryUiState.Success -> {
+//            val (smeemData, planData, + 배지) = uiState
+            val (smeemData, planData) = uiState
 
+            Column(
+                modifier = modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                VerticalSpacer(height = 18.dp)
 
-    /***** bottom sheet configuration *****/
-    val sheetState = rememberModalBottomSheetState()
-    val coroutineScope = rememberCoroutineScope()
-    var selectedBadge by rememberSaveable { mutableStateOf<MyBadges?>(null) }
+                MySmeemCard(mySmeem = smeemData)
 
-    if (selectedBadge != null) {
-        MyBadgesBottomSheet(
-            badge = selectedBadge!!,
-            sheetState = sheetState,
-            onDismiss = {
-                selectedBadge = null
-                coroutineScope.launch { sheetState.hide() }
+                VerticalSpacer(height = 44.dp)
+
+                MyPlanCard(myPlan = planData)
+
+                VerticalSpacer(height = 36.dp)
+
+                MyBadgesContent(
+                    badges = BadgeList.sprint2,
+                    onClickCard = { clickedBadge -> selectedBadge = clickedBadge },
+                    modifier = Modifier.heightIn(max = 1000.dp)
+                )
+    
+                VerticalSpacer(height = 120.dp)
             }
-        )
+        }
+
+        is MySummaryUiState.Error -> {
+            // ErrorScreen
+        }
+       
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        VerticalSpacer(height = 18.dp)
 
-        MySmeemCard(mySmeem = mockMySmeem)
-
-        VerticalSpacer(height = 44.dp)
-
-        MyPlanCard(myPlan = mockMyPlan)
-
-        VerticalSpacer(height = 36.dp)
-
-        MyBadgesContent(
-            badges = BadgeList.sprint2,
-            onClickCard = { clickedBadge -> selectedBadge = clickedBadge },
-            modifier = Modifier.heightIn(max = 1000.dp)
-        )
-
-        VerticalSpacer(height = 120.dp)
-    }
 }
 
 @Preview(showSystemUi = true, showBackground = true)
 @Composable
 fun MySummaryScreenPreview() {
-    SmeemTheme {
-        MySummaryScreen(navController = rememberNavController(), modifier = Modifier)
-    }
+    MySummaryScreen(viewModel = hiltViewModel(), modifier = Modifier)
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryScreen.kt
@@ -17,17 +17,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.smeem.data.datasource.BadgeList
 import com.sopt.smeem.domain.model.mypage.MyBadges
-import com.sopt.smeem.domain.model.mypage.MyPlan
-import com.sopt.smeem.domain.model.mypage.MySmeem
-import com.sopt.smeem.presentation.compose.theme.SmeemTheme
+import com.sopt.smeem.presentation.compose.components.LoadingScreen
 import com.sopt.smeem.presentation.mypage.components.MyBadgesBottomSheet
 import com.sopt.smeem.presentation.mypage.components.MyBadgesContent
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.sopt.smeem.presentation.compose.components.LoadingScreen
 import com.sopt.smeem.presentation.mypage.components.MyPlanCard
 import com.sopt.smeem.presentation.mypage.components.MySmeemCard
 import com.sopt.smeem.util.VerticalSpacer
@@ -42,6 +37,22 @@ fun MySummaryScreen(
 ) {
     val state by viewModel.collectAsState()
 
+    /***** bottom sheet configuration *****/
+    val sheetState = rememberModalBottomSheetState()
+    val coroutineScope = rememberCoroutineScope()
+    var selectedBadge by rememberSaveable { mutableStateOf<MyBadges?>(null) }
+
+    if (selectedBadge != null) {
+        MyBadgesBottomSheet(
+            badge = selectedBadge!!,
+            sheetState = sheetState,
+            onDismiss = {
+                selectedBadge = null
+                coroutineScope.launch { sheetState.hide() }
+            }
+        )
+    }
+
     when (val uiState = state.uiState) {
         is MySummaryUiState.Loading -> {
             LoadingScreen()
@@ -52,7 +63,9 @@ fun MySummaryScreen(
             val (smeemData, planData) = uiState
 
             Column(
-                modifier = modifier.fillMaxSize(),
+                modifier = modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 VerticalSpacer(height = 18.dp)
@@ -70,7 +83,7 @@ fun MySummaryScreen(
                     onClickCard = { clickedBadge -> selectedBadge = clickedBadge },
                     modifier = Modifier.heightIn(max = 1000.dp)
                 )
-    
+
                 VerticalSpacer(height = 120.dp)
             }
         }
@@ -78,10 +91,7 @@ fun MySummaryScreen(
         is MySummaryUiState.Error -> {
             // ErrorScreen
         }
-       
     }
-
-
 }
 
 @Preview(showSystemUi = true, showBackground = true)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummarySideEffect.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummarySideEffect.kt
@@ -1,0 +1,4 @@
+package com.sopt.smeem.presentation.mypage.mysummary
+
+sealed class MySummarySideEffect {
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryState.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryState.kt
@@ -1,0 +1,5 @@
+package com.sopt.smeem.presentation.mypage.mysummary
+
+data class MySummaryState(
+    val uiState: MySummaryUiState = MySummaryUiState.Loading,
+)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryUiState.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryUiState.kt
@@ -1,0 +1,15 @@
+package com.sopt.smeem.presentation.mypage.mysummary
+
+import com.sopt.smeem.domain.dto.MyPlanDto
+import com.sopt.smeem.domain.dto.MySmeemDataDto
+
+sealed class MySummaryUiState {
+    data object Loading : MySummaryUiState()
+    data class Success(
+        val smeemData: MySmeemDataDto,
+        val planData: MyPlanDto?,
+//        val badgesData: List<GetBadgeListDto>
+    ) : MySummaryUiState()
+
+    data class Error(val message: String) : MySummaryUiState()
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryViewModel.kt
@@ -1,0 +1,49 @@
+package com.sopt.smeem.presentation.mypage.mysummary
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sopt.smeem.data.usecase.MySummaryUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class MySummaryViewModel @Inject constructor(
+    private val mySummaryUseCase: MySummaryUseCase
+) : ContainerHost<MySummaryState, MySummarySideEffect>,
+    ViewModel() {
+
+    override val container = container<MySummaryState, MySummarySideEffect>(MySummaryState())
+
+    init {
+        fetchMySummaryData()
+    }
+
+    private fun fetchMySummaryData() {
+        viewModelScope.launch {
+            intent {
+                reduce {
+                    state.copy(uiState = MySummaryUiState.Loading)
+                }
+                Timber.e("fetchMySummaryData loading")
+            }
+
+            // TODO : 배지 반영 -> 주석 해제
+            // val (smeemData, planData, badgesData) = mySummaryUseCase()
+            val (smeemData, planData) = mySummaryUseCase()
+
+            intent {
+                reduce {
+                    state.copy(uiState = MySummaryUiState.Success(smeemData, planData))
+                }
+                Timber.e("fetchMySummaryData success")
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -28,6 +29,7 @@ import com.sopt.smeem.presentation.mypage.components.topbar.SettingTopAppBar
 import com.sopt.smeem.presentation.mypage.components.topbar.TitleTopAppbar
 import com.sopt.smeem.presentation.mypage.more.MoreScreen
 import com.sopt.smeem.presentation.mypage.mysummary.MySummaryScreen
+import com.sopt.smeem.presentation.mypage.mysummary.MySummaryViewModel
 import com.sopt.smeem.presentation.mypage.setting.ChangeNicknameScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingPlanScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeScreen
@@ -97,8 +99,10 @@ fun MyPageNavHost(
 
 private fun NavGraphBuilder.addMySummary(navController: NavController, modifier: Modifier) {
     composable(route = MyPageScreen.MySummary.route) {
+        val viewModel: MySummaryViewModel = hiltViewModel()
+
         MySummaryScreen(
-            navController = navController,
+            viewModel = viewModel,
             modifier = modifier
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ retrofit = "2.11.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
 secretsGradlePlugin = "2.0.1"
 securityCryptoKtx = "1.1.0-alpha05"
+orbit = "4.4.0"
 timber = "5.0.1"
 v2User = "2.13.0"
 kotlin = "1.9.22"
@@ -103,8 +104,16 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "v2User" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 
+orbit-core = { group = "org.orbit-mvi", name = "orbit-core", version.ref = "orbit" }
+orbit-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbit" }
+orbit-compose = { group = "org.orbit-mvi", name = "orbit-compose", version.ref = "orbit" }
+orbit-test = { group = "org.orbit-mvi", name = "orbit-test", version.ref = "orbit" }
+
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
+
+[bundles]
+orbit = ["orbit-core", "orbit-viewmodel", "orbit-compose", "orbit-test"]
 


### PR DESCRIPTION
- resolved #268 

## *⛳️ Work Description*
- MySummaryUseCase에서 Repository 불러와서 데이터 가져오기 
- Orbit 라이브러리 사용해서 상태 변화 (의존성도 추가함) 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

### delay 없을 때

https://github.com/Team-Smeme/smeem-aos/assets/98825364/bb1b362a-cd50-4be0-bcac-9ab0130ef2c4

### 3초 delay 주었을 때

https://github.com/Team-Smeme/smeem-aos/assets/98825364/7f2682a1-168d-4b43-ad90-fad023b320f2


## *📢 To Reviewers*
- 로딩뷰가 있는게 나은지 없는게 나은지 기디에게 물어보고 반영할게요 일단 만듦
- 배지쪽 어떻게 하면 되는지 주석처리 해두었으니 나중에 가공해서 Usecase에 추가하실 때 주석 적절하게 지우거나 수정해서 반영해주세요~ @wateralsie 
- UseCase 쪽 로직 괜찮은지 한번 봐주시면 감사하겠습니다 :) @daehwan2yo 
- 그리고 UiState가 Error일 때는 어떤 상황은 두면 좋을까요? 일단 SideEffect로 ToastMessage를 띄우면 어떨까 고민중입니다
