### PR TITLE
[마이페이지] 설정 api 연결 및 학습알림 수정 페이지 연동

### DIFF
--- a/app/src/main/java/com/sopt/smeem/data/model/response/MyInfoResponse.kt
+++ b/app/src/main/java/com/sopt/smeem/data/model/response/MyInfoResponse.kt
@@ -7,10 +7,16 @@ data class MyInfoResponse(
     val targetLang: String,
     val hasPushAlarm: Boolean,
     val trainingTime: MyTrainingTimeResponse?,
+    val trainingPlan: MyTrainingPlanResponse?
 ) {
     data class MyTrainingTimeResponse(
         val day: String,
         val hour: Int,
         val minute: Int
+    )
+
+    data class MyTrainingPlanResponse(
+        val id: Int,
+        val content: String
     )
 }

--- a/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
@@ -16,6 +16,7 @@ import com.sopt.smeem.domain.dto.PostOnBoardingDto
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.PushAlarm
 import com.sopt.smeem.domain.model.Training
+import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.domain.repository.UserRepository
 
 class UserRepositoryImpl(
@@ -126,8 +127,8 @@ class UserRepositoryImpl(
                             targetLang = data.targetLang,
                             hasPushAlarm = data.hasPushAlarm,
                             trainingTime = data.trainingTime?.let {
-                                MyInfoDto.MyTrainingTime(
-                                    day = it.day.split(",").map { Day.valueOf(it) }
+                                TrainingTime(
+                                    days = it.day.split(",").map { Day.valueOf(it) }
                                         .toSet(),
                                     hour = it.hour,
                                     minute = it.minute

--- a/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
@@ -175,7 +175,7 @@ class UserRepositoryImpl(
                 target = training.type,
                 trainingTime = training.extractTime(),
                 hasAlarm = training.hasAlarm,
-                planId = 0, // FIXME : 구현시 수정
+                planId = null, // FIXME : 구현시 수정
             )
         ).let { resposne ->
             if (resposne.isSuccessful) {

--- a/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/data/repository/UserRepositoryImpl.kt
@@ -132,6 +132,12 @@ class UserRepositoryImpl(
                                     hour = it.hour,
                                     minute = it.minute
                                 )
+                            },
+                            trainingPlan = data.trainingPlan?.let {
+                                MyInfoDto.MyTrainingPlan(
+                                    id = it.id,
+                                    content = it.content
+                                )
                             }
                         )
                     )

--- a/app/src/main/java/com/sopt/smeem/domain/dto/MyInfoDto.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/dto/MyInfoDto.kt
@@ -9,10 +9,16 @@ data class MyInfoDto(
     val targetLang: String,
     val hasPushAlarm: Boolean,
     val trainingTime: MyTrainingTime?,
+    val trainingPlan: MyTrainingPlan?
 ) {
     data class MyTrainingTime(
         val day: Set<Day>,
         val hour: Int,
         val minute: Int,
+    )
+
+    data class MyTrainingPlan(
+        val id: Int,
+        val content: String,
     )
 }

--- a/app/src/main/java/com/sopt/smeem/domain/dto/MyInfoDto.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/dto/MyInfoDto.kt
@@ -1,6 +1,6 @@
 package com.sopt.smeem.domain.dto
 
-import com.sopt.smeem.domain.model.Day
+import com.sopt.smeem.domain.model.TrainingTime
 
 data class MyInfoDto(
     val username: String,
@@ -8,15 +8,9 @@ data class MyInfoDto(
     val detail: String,
     val targetLang: String,
     val hasPushAlarm: Boolean,
-    val trainingTime: MyTrainingTime?,
+    val trainingTime: TrainingTime?,
     val trainingPlan: MyTrainingPlan?
 ) {
-    data class MyTrainingTime(
-        val day: Set<Day>,
-        val hour: Int,
-        val minute: Int,
-    )
-
     data class MyTrainingPlan(
         val id: Int,
         val content: String,

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/Picker.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/Picker.kt
@@ -35,10 +35,13 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 @Composable
-fun rememberPickerState() = remember { PickerState() }
+fun rememberPickerState(initialSelectedItem: String = "") = remember {
+    PickerState(initialSelectedItem)
+}
 
-class PickerState {
-    var selectedItem by mutableStateOf("")
+
+class PickerState(initialSelectedItem: String = "") {
+    var selectedItem by mutableStateOf(initialSelectedItem)
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -51,6 +51,7 @@ fun SmeemAlarmCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
             .noRippleClickable { if (isActive && !isContentClickable) onAlarmCardClick() }
     ) {
         LazyRow(

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -32,6 +32,7 @@ import com.sopt.smeem.util.sideBorder
 @Composable
 fun SmeemAlarmCard(
     modifier: Modifier = Modifier,
+    isActive: Boolean,
     isDaySelected: (String) -> Boolean,
     trainingTime: String = stringResource(R.string.default_training_time),
     onAlarmCardClick: () -> Unit = {},
@@ -51,7 +52,7 @@ fun SmeemAlarmCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .noRippleClickable { onAlarmCardClick() }
+            .noRippleClickable { if (isActive && !isContentClickable) onAlarmCardClick() }
     ) {
         LazyRow(
             modifier = Modifier
@@ -162,5 +163,6 @@ fun SmeemAlarmDaysPreview() {
     val mockDays = arrayOf("월", "화", "수", "목", "금")
     SmeemAlarmCard(
         modifier = Modifier.padding(horizontal = 19.dp),
+        isActive = true,
         isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -33,11 +33,11 @@ import com.sopt.smeem.util.sideBorder
 fun SmeemAlarmCard(
     modifier: Modifier = Modifier,
     isActive: Boolean,
-    isDaySelected: (String) -> Boolean,
+    selectedDays: MutableSet<Day>,
     trainingTime: String = stringResource(R.string.default_training_time),
     onAlarmCardClick: () -> Unit = {},
     isContentClickable: Boolean = false,
-    onDayClick: (String) -> Unit = {},
+    onDayClick: (Day) -> Unit = {},
     onTimeCardClick: () -> Unit = {}
 ) {
 
@@ -61,7 +61,7 @@ fun SmeemAlarmCard(
                 .background(white)
         ) {
             items(daysOfWeek.size) { day ->
-                val daySelected = isDaySelected(daysOfWeek[day])
+                val daySelected = selectedDays.contains(Day.from(daysOfWeek[day]))
                 val borderColor = if (daySelected) point else gray200
                 val sideBorder = Border(strokeWidth = 1.dp, color = borderColor)
 
@@ -113,7 +113,7 @@ fun SmeemAlarmCard(
 
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier = itemModifier
+                    modifier = itemModifier.noRippleClickable { onDayClick(Day.from(daysOfWeek[day])) }
                 ) {
                     Text(
                         text = daysOfWeek[day],
@@ -166,20 +166,22 @@ fun SmeemAlarmCard(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SmeemAlarmDaysPreview() {
-    val mockDays = arrayOf("월", "화", "수", "목", "금")
     SmeemAlarmCard(
         modifier = Modifier.padding(horizontal = 19.dp),
         isActive = true,
-        isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
+        selectedDays = mutableSetOf(Day.MON, Day.TUE, Day.WED, Day.THU, Day.FRI),
+        onAlarmCardClick = {}
+    )
 }
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun InActiveSmeemAlarmDaysPreview() {
-    val mockDays = arrayOf("월", "화", "수", "목", "금")
     SmeemAlarmCard(
         modifier = Modifier.padding(horizontal = 19.dp),
         isActive = false,
-        isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
+        selectedDays = mutableSetOf(Day.MON, Day.TUE, Day.WED, Day.THU, Day.FRI),
+        onAlarmCardClick = {}
+    )
 }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemAlarmCard.kt
@@ -44,9 +44,8 @@ fun SmeemAlarmCard(
     val daysOfWeek = Day.entries.map { it.korean }
 
     // 화면의 가로 길이를 가져와서 요일의 개수로 나누어 요일의 너비를 계산
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val itemWidth = with(LocalConfiguration.current) {
-        (screenWidth - 38.dp) / daysOfWeek.size
+        (screenWidthDp.dp - 38.dp) / daysOfWeek.size
     }
 
     Column(
@@ -74,7 +73,13 @@ fun SmeemAlarmCard(
                 val itemModifier = Modifier
                     .size(itemWidth)
                     .then(radiusModifier)
-                    .background(if (daySelected) point else white)
+                    .background(
+                        when {
+                            daySelected && isActive -> point
+                            daySelected -> gray200
+                            else -> white
+                        }
+                    )
                     .then(
                         if (!daySelected) {
                             Modifier
@@ -142,7 +147,7 @@ fun SmeemAlarmCard(
                 Text(
                     text = stringResource(R.string.my_page_setting_training_time_title),
                     style = Typography.labelLarge,
-                    color = point
+                    color = if (isActive) point else gray200
                 )
 
                 VerticalSpacer(height = 4.dp)
@@ -150,7 +155,7 @@ fun SmeemAlarmCard(
                 Text(
                     text = trainingTime,
                     style = Typography.titleMedium,
-                    color = point
+                    color = if (isActive) point else gray200
                 )
             }
         }
@@ -166,3 +171,14 @@ fun SmeemAlarmDaysPreview() {
         isActive = true,
         isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
 }
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun InActiveSmeemAlarmDaysPreview() {
+    val mockDays = arrayOf("월", "화", "수", "목", "금")
+    SmeemAlarmCard(
+        modifier = Modifier.padding(horizontal = 19.dp),
+        isActive = false,
+        isDaySelected = { mockDays.contains(it) }, onAlarmCardClick = {})
+}
+

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
@@ -35,6 +35,8 @@ fun SmeemTimePickerDialog(
     setShowDialog: (Boolean) -> Unit,
     onDismissRequest: () -> Unit,
     onSaveButtonClick: () -> Unit,
+    initialHour: Int,
+    initialMinute: Int,
     modifier: Modifier = Modifier,
 ) {
 
@@ -77,6 +79,7 @@ fun SmeemTimePickerDialog(
                         state = timeOfDayPickerState,
                         items = timeOfDay,
                         visibleItemsCount = 3,
+                        startIndex = if (initialHour < 12 || initialHour == 24) 0 else 1,
                         textModifier = Modifier.padding(18.dp),
                         modifier = Modifier.weight(1f),
                         textStyle = Typography.titleSmall.copy(color = black),
@@ -89,6 +92,7 @@ fun SmeemTimePickerDialog(
                         state = hourPickerState,
                         items = hour,
                         visibleItemsCount = 3,
+                        startIndex = if (initialHour <= 12) initialHour - 1 else initialHour - 13,
                         textModifier = Modifier.padding(18.dp),
                         modifier = Modifier
                             .weight(1f)
@@ -113,6 +117,7 @@ fun SmeemTimePickerDialog(
                         state = minutePickerState,
                         items = minute,
                         visibleItemsCount = 3,
+                        startIndex = if (initialMinute == 0) 0 else 1,
                         textModifier = Modifier.padding(18.dp),
                         modifier = Modifier.weight(1f),
                         textStyle = Typography.titleSmall.copy(color = black),
@@ -163,6 +168,8 @@ fun PreviewSmeemTimePickerDialog() {
     SmeemTimePickerDialog(
         setShowDialog = {},
         onSaveButtonClick = {},
+        initialHour = 13,
+        initialMinute = 30,
         onDismissRequest = {}
     )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
@@ -34,7 +34,7 @@ import com.sopt.smeem.util.VerticalSpacer
 fun SmeemTimePickerDialog(
     setShowDialog: (Boolean) -> Unit,
     onDismissRequest: () -> Unit,
-    onSaveButtonClick: () -> Unit,
+    onSaveButtonClick: (Int, Int) -> Unit,
     initialHour: Int,
     initialMinute: Int,
     modifier: Modifier = Modifier,
@@ -46,9 +46,19 @@ fun SmeemTimePickerDialog(
     val hour = remember { (1..12).map { it.toString() } }
     val minute = remember { listOf("00", "30") }
 
-    val timeOfDayPickerState = rememberPickerState()
-    val hourPickerState = rememberPickerState()
-    val minutePickerState = rememberPickerState()
+    val timeOfDayPickerState = rememberPickerState("오전")
+    val hourPickerState = rememberPickerState("1")
+    val minutePickerState = rememberPickerState("00")
+
+    val selectedTimeOfDay = timeOfDayPickerState.selectedItem
+    val selectedHour = hourPickerState.selectedItem.toInt()
+    val selectedMinute = minutePickerState.selectedItem.toInt()
+
+    val selectedHour24 = if (selectedTimeOfDay == "오후") {
+        if (selectedHour == 12) selectedHour else selectedHour + 12
+    } else {
+        if (selectedHour == 12) 0 else selectedHour
+    }
 
     Dialog(onDismissRequest = onDismissRequest) {
         Surface(
@@ -148,7 +158,7 @@ fun SmeemTimePickerDialog(
                     HorizontalSpacer(width = 8.dp)
 
                     TextButton(
-                        onClick = onSaveButtonClick,
+                        onClick = { onSaveButtonClick(selectedHour24, selectedMinute) },
                     ) {
                         Text(
                             text = "저장",
@@ -167,7 +177,7 @@ fun SmeemTimePickerDialog(
 fun PreviewSmeemTimePickerDialog() {
     SmeemTimePickerDialog(
         setShowDialog = {},
-        onSaveButtonClick = {},
+        onSaveButtonClick = { _, _ -> },
         initialHour = 13,
         initialMinute = 30,
         onDismissRequest = {}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTimePickerFragment.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTimePickerFragment.kt
@@ -29,8 +29,8 @@ class EditTimePickerFragment : DialogFragment() {
             .setView(timePicker.root)
             .setNegativeButton("취소", null)
             .setPositiveButton("저장") { _, _ ->
-                vm.hour.value = if (hourPicker.value == 0) 24 else hourPicker.value
-                vm.minute.value = minutePicker.value * MINUTE_INTERVAL
+//                vm.hour.value = if (hourPicker.value == 0) 24 else hourPicker.value
+//                vm.minute.value = minutePicker.value * MINUTE_INTERVAL
             }
             .create()
     }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTimePickerFragment.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTimePickerFragment.kt
@@ -7,9 +7,9 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.sopt.smeem.databinding.DialogTimePickerBinding
-import com.sopt.smeem.presentation.mypage.EditTrainingTimeViewModel.Companion.DEFAULT_HOUR
-import com.sopt.smeem.presentation.mypage.EditTrainingTimeViewModel.Companion.DEFAULT_MINUTE
-import com.sopt.smeem.presentation.onboarding.OnBoardingVM
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel.Companion.DEFAULT_HOUR
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel.Companion.DEFAULT_MINUTE
 
 class EditTimePickerFragment : DialogFragment() {
     private val timePicker by lazy { DialogTimePickerBinding.inflate(layoutInflater) }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
@@ -11,7 +11,6 @@ import com.sopt.smeem.presentation.IntentConstants.SNACKBAR_TEXT
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel
 import com.sopt.smeem.util.ButtonUtil.switchOff
 import com.sopt.smeem.util.ButtonUtil.switchOn
-import com.sopt.smeem.util.DateUtil
 import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -109,15 +108,15 @@ class EditTrainingTimeActivity :
     }
 
     private fun observeTime() {
-        viewModel.hour.observe(this) {
-            binding.tvMyPageEditTimeHour.text = "%02d".format(DateUtil.asHour(it))
-            binding.tvMyPageEditTimeAmpm.text = " ${DateUtil.asAmpm(it)}"
-            checkSelection()
-        }
-        viewModel.minute.observe(this) {
-            binding.tvMyPageEditTimeMinute.text = DateUtil.asMinute(it)
-            checkSelection()
-        }
+//        viewModel.hour.observe(this) {
+//            binding.tvMyPageEditTimeHour.text = "%02d".format(DateUtil.asHour(it))
+//            binding.tvMyPageEditTimeAmpm.text = " ${DateUtil.asAmpm(it)}"
+//            checkSelection()
+//        }
+//        viewModel.minute.observe(this) {
+//            binding.tvMyPageEditTimeMinute.text = DateUtil.asMinute(it)
+//            checkSelection()
+//        }
     }
 
     private fun setDaysHeight() {

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
@@ -1,20 +1,17 @@
 package com.sopt.smeem.presentation.mypage
 
 import android.content.Intent
-import android.util.Log
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
 import com.sopt.smeem.R
 import com.sopt.smeem.databinding.ActivityEditTrainingTimeBinding
-import com.sopt.smeem.description
-import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.BindingActivity
 import com.sopt.smeem.presentation.IntentConstants.SNACKBAR_TEXT
+import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel
 import com.sopt.smeem.util.ButtonUtil.switchOff
 import com.sopt.smeem.util.ButtonUtil.switchOn
 import com.sopt.smeem.util.DateUtil
-import com.sopt.smeem.util.getParcelable
 import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -26,7 +23,7 @@ class EditTrainingTimeActivity :
 
     override fun constructLayout() {
         setUpDays()
-        initData()
+//        initData()
     }
 
     override fun addListeners() {
@@ -53,19 +50,19 @@ class EditTrainingTimeActivity :
         )
     }
 
-    private fun initData() {
-        binding.trainingTime = intent.getParcelable("selectedTime", TrainingTime::class.java)
-        viewModel.originalTime = binding.trainingTime!!
-
-        viewModel.hour.value = binding.trainingTime!!.hour
-        viewModel.minute.value = binding.trainingTime!!.minute
-        viewModel.days.addAll(binding.trainingTime!!.days)
-        days?.values?.forEach { day ->
-            if (viewModel.isDaySelected(day.text.toString())) {
-                day.switchOn()
-            }
-        }
-    }
+//    private fun initData() {
+//        binding.trainingTime = intent.getParcelable("selectedTime", TrainingTime::class.java)
+//        viewModel.originalTime = binding.trainingTime!!
+//
+//        viewModel.hour.value = binding.trainingTime!!.hour
+//        viewModel.minute.value = binding.trainingTime!!.minute
+//        viewModel.days.addAll(binding.trainingTime!!.days)
+//        days?.values?.forEach { day ->
+//            if (viewModel.isDaySelected(day.text.toString())) {
+//                day.switchOn()
+//            }
+//        }
+//    }
 
     private fun onTouchBack() {
         binding.topbarMyPageEditTime.setNavigationOnClickListener {

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/EditTrainingTimeActivity.kt
@@ -97,13 +97,20 @@ class EditTrainingTimeActivity :
 
     private fun onTouchComplete() {
         binding.btnMyPageEditTime.setOnSingleClickListener {
-            viewModel.sendServer { t ->
-                Toast.makeText(applicationContext, t.message, Toast.LENGTH_SHORT).show()
-            }
-            Intent(this, MyPageActivity::class.java).apply {
-                putExtra(SNACKBAR_TEXT, resources.getString(R.string.my_page_edit_done_message))
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            }.run(::startActivity)
+            viewModel.sendServer(
+                onSuccess = {
+                    Intent(this, MyPageActivity::class.java).apply {
+                        putExtra(
+                            SNACKBAR_TEXT,
+                            resources.getString(R.string.my_page_edit_done_message)
+                        )
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    }.run(::startActivity)
+                },
+                onError = { t ->
+                    Toast.makeText(applicationContext, t.message, Toast.LENGTH_SHORT).show()
+                }
+            )
         }
     }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/ChangeMyPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/ChangeMyPlanCard.kt
@@ -8,12 +8,12 @@ import com.sopt.smeem.R
 @Composable
 fun ChangeMyPlanCard(
     isPlanSet: Boolean = true,
-    myPlan: String,
+    myPlan: String?,
     onEditClick: () -> Unit,
 ) {
     SmeemContents(title = stringResource(R.string.my_plan)) {
         SmeemCard(
-            text = if (isPlanSet) myPlan else stringResource(R.string.no_plan_title),
+            text = if (isPlanSet) myPlan!! else stringResource(R.string.no_plan_title),
             isActive = isPlanSet
         ) {
             EditButton(

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/ChangeMyPlanCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/ChangeMyPlanCard.kt
@@ -7,15 +7,18 @@ import com.sopt.smeem.R
 
 @Composable
 fun ChangeMyPlanCard(
+    isPlanSet: Boolean = true,
     myPlan: String,
     onEditClick: () -> Unit,
 ) {
     SmeemContents(title = stringResource(R.string.my_plan)) {
         SmeemCard(
-            // TODO : arg로 받아온 값 넣어주기
-            text = myPlan,
+            text = if (isPlanSet) myPlan else stringResource(R.string.no_plan_title),
+            isActive = isPlanSet
         ) {
-            EditButton {
+            EditButton(
+                text = if (isPlanSet) stringResource(R.string.smeem_card_edit) else stringResource(R.string.set_my_plan)
+            ) {
                 onEditClick()
             }
         }
@@ -26,6 +29,16 @@ fun ChangeMyPlanCard(
 @Composable
 fun ChangeMyPlanCardPreview() {
     ChangeMyPlanCard(
+        myPlan = "주 3회 일기 작성하기",
+        onEditClick = {}
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun ChangeNoMyPlanCardPreview() {
+    ChangeMyPlanCard(
+        isPlanSet = false,
         myPlan = "주 3회 일기 작성하기",
         onEditClick = {}
     )

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/SmeemCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/SmeemCard.kt
@@ -21,12 +21,14 @@ import com.sopt.smeem.R
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.black
 import com.sopt.smeem.presentation.compose.theme.gray100
+import com.sopt.smeem.presentation.compose.theme.gray500
 import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.compose.theme.white
 
 @Composable
 fun SmeemCard(
     modifier: Modifier = Modifier,
+    isActive: Boolean = true,
     text: String,
     content: @Composable () -> Unit,
 ) {
@@ -44,7 +46,7 @@ fun SmeemCard(
             Text(
                 text = text,
                 style = Typography.bodySmall,
-                color = black,
+                color = if (isActive) black else gray500,
                 modifier = Modifier.padding(top = 17.dp, bottom = 18.dp)
             )
 
@@ -57,7 +59,8 @@ fun SmeemCard(
 
 @Composable
 fun EditButton(
-    action: () -> Unit
+    text: String = stringResource(R.string.smeem_card_edit),
+    action: () -> Unit,
 ) {
     Button(
         onClick = action,
@@ -67,7 +70,7 @@ fun EditButton(
         contentPadding = PaddingValues(0.dp),
     ) {
         Text(
-            text = stringResource(R.string.smeem_card_edit),
+            text = text,
             style = Typography.labelMedium,
             color = point,
             modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 18.dp, bottom = 19.dp)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/mysummary/MySummaryViewModel.kt
@@ -9,7 +9,6 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,7 +29,6 @@ class MySummaryViewModel @Inject constructor(
                 reduce {
                     state.copy(uiState = MySummaryUiState.Loading)
                 }
-                Timber.e("fetchMySummaryData loading")
             }
 
             // TODO : 배지 반영 -> 주석 해제
@@ -41,7 +39,6 @@ class MySummaryViewModel @Inject constructor(
                 reduce {
                     state.copy(uiState = MySummaryUiState.Success(smeemData, planData))
                 }
-                Timber.e("fetchMySummaryData success")
             }
         }
     }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -34,6 +34,7 @@ import com.sopt.smeem.presentation.mypage.setting.ChangeNicknameScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingPlanScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeScreen
 import com.sopt.smeem.presentation.mypage.setting.SettingScreen
+import com.sopt.smeem.presentation.mypage.setting.SettingViewModel
 
 @Composable
 fun MyPageNavHost(
@@ -115,8 +116,11 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
         route = MyPageScreen.Setting.route
     ) {
         composable(route = SettingNavGraph.SettingMain.route) {
+            val viewModel: SettingViewModel = hiltViewModel()
+
             SettingScreen(
                 navController = navController,
+                viewModel = viewModel,
                 modifier = modifier
             )
         }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -158,6 +158,7 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
             }
 
             EditTrainingTimeScreen(
+                navController = navController,
                 modifier = modifier,
                 trainingTime = trainingTime.value,
             )

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -30,7 +30,6 @@ import com.sopt.smeem.presentation.mypage.setting.ChangeNicknameScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingPlanScreen
 import com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeScreen
 import com.sopt.smeem.presentation.mypage.setting.SettingScreen
-import com.sopt.smeem.presentation.mypage.setting.SettingViewModel
 
 @Composable
 fun MyPageNavHost(
@@ -112,11 +111,9 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
         route = MyPageScreen.Setting.route
     ) {
         composable(route = SettingNavGraph.SettingMain.route) {
-            val viewModel: SettingViewModel = hiltViewModel()
 
             SettingScreen(
                 navController = navController,
-                viewModel = viewModel,
                 modifier = modifier
             )
         }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -3,10 +3,7 @@ package com.sopt.smeem.presentation.mypage.navigation
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -21,7 +18,6 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.sopt.smeem.R
-import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.mypage.TempMyPageActivity
 import com.sopt.smeem.presentation.mypage.components.topbar.MySummaryTopAppBar
 import com.sopt.smeem.presentation.mypage.components.topbar.OnlyBackArrowTopAppBar
@@ -146,21 +142,10 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
         composable(
             route = SettingNavGraph.EditTrainingTime.route,
         ) {
-            var trainingTime = rememberSaveable { mutableStateOf(TrainingTime(setOf(), 0, 0)) }
-
-            LaunchedEffect(key1 = it) {
-                val result =
-                    navController.previousBackStackEntry?.savedStateHandle?.get<TrainingTime>("trainingTime")
-
-                result?.let {
-                    trainingTime.value = it
-                }
-            }
 
             EditTrainingTimeScreen(
                 navController = navController,
                 modifier = modifier,
-                trainingTime = trainingTime.value,
             )
         }
     }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -1,5 +1,6 @@
 package com.sopt.smeem.presentation.mypage.setting
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,6 +37,7 @@ fun EditTrainingTimeScreen(
 
     viewModel.originalTime = trainingTime
 
+    val context = LocalContext.current
     var showTimePickDialog by rememberSaveable { mutableStateOf(false) }
     val selectedDays by viewModel.days.collectAsStateWithLifecycle()
     val selectedHour by viewModel.hour.collectAsStateWithLifecycle()
@@ -61,9 +64,14 @@ fun EditTrainingTimeScreen(
 
         SmeemButton(
             text = stringResource(R.string.training_time_change_button),
-            onClick = { /*TODO*/ },
+            onClick = {
+                viewModel.sendServer { t ->
+                    Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                }
+                navController.popBackStack()
+            },
             modifier = Modifier.padding(horizontal = 18.dp),
-            isButtonEnabled = true
+            isButtonEnabled = viewModel.canConfirmEdit()
         )
 
         VerticalSpacer(height = 10.dp)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -20,22 +22,25 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.sopt.smeem.R
-import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
 import com.sopt.smeem.presentation.compose.components.SmeemButton
 import com.sopt.smeem.presentation.compose.components.SmeemTimePickerDialog
+import com.sopt.smeem.presentation.mypage.navigation.MyPageScreen
 import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
 fun EditTrainingTimeScreen(
     navController: NavController,
     modifier: Modifier = Modifier,
-    trainingTime: TrainingTime,
     viewModel: EditTrainingTimeViewModel = hiltViewModel()
 ) {
-
-    viewModel.originalTime = trainingTime
+    val trainingTimeResult = remember {
+        navController.previousBackStackEntry?.savedStateHandle?.get<TrainingTime>("trainingTime")
+    }
+    LaunchedEffect(trainingTimeResult) {
+        trainingTimeResult?.let { viewModel.initialize(it) }
+    }
 
     val context = LocalContext.current
     var showTimePickDialog by rememberSaveable { mutableStateOf(false) }
@@ -68,7 +73,11 @@ fun EditTrainingTimeScreen(
                 viewModel.sendServer { t ->
                     Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
                 }
-                navController.popBackStack()
+                navController.navigate(MyPageScreen.Setting.route) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = false
+                    }
+                }
             },
             modifier = Modifier.padding(horizontal = 18.dp),
             isButtonEnabled = viewModel.canConfirmEdit()
@@ -98,6 +107,6 @@ fun EditTrainingTimeScreen(
 fun PreviewEditTrainingTimeScreen() {
     EditTrainingTimeScreen(
         navController = rememberNavController(),
-        trainingTime = TrainingTime(setOf(Day.MON, Day.THU), 10, 30),
+        viewModel = hiltViewModel()
     )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -37,6 +37,9 @@ fun EditTrainingTimeScreen(
 
     var showTimePickDialog by rememberSaveable { mutableStateOf(false) }
     val selectedDays by viewModel.days.collectAsStateWithLifecycle()
+    val selectedHour by viewModel.hour.collectAsStateWithLifecycle()
+    val selectedMinute by viewModel.minute.collectAsStateWithLifecycle()
+    val updatedTrainingTime = TrainingTime(selectedDays, selectedHour, selectedMinute)
 
     Column(modifier = modifier.fillMaxWidth()) {
 
@@ -46,7 +49,7 @@ fun EditTrainingTimeScreen(
             modifier = Modifier.padding(horizontal = 19.dp),
             isActive = true,
             selectedDays = selectedDays,
-            trainingTime = "${trainingTime.asHour()}:${trainingTime.asMinute()} ${trainingTime.asAmpm()}",
+            trainingTime = updatedTrainingTime.asText(),
             onTimeCardClick = { showTimePickDialog = true },
             isContentClickable = true,
             onDayClick = { day ->
@@ -71,7 +74,12 @@ fun EditTrainingTimeScreen(
         SmeemTimePickerDialog(
             setShowDialog = { showTimePickDialog = it },
             onDismissRequest = { showTimePickDialog = false },
-            onSaveButtonClick = { }
+            onSaveButtonClick = { hour, minute ->
+                viewModel.updateHourMinute(hour, minute)
+                showTimePickDialog = false
+            },
+            initialHour = selectedHour,
+            initialMinute = selectedMinute
         )
     }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -70,14 +70,18 @@ fun EditTrainingTimeScreen(
         SmeemButton(
             text = stringResource(R.string.training_time_change_button),
             onClick = {
-                viewModel.sendServer { t ->
-                    Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
-                }
-                navController.navigate(MyPageScreen.Setting.route) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        saveState = false
+                viewModel.sendServer(
+                    onSuccess = {
+                        navController.navigate(MyPageScreen.Setting.route) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = false
+                            }
+                        }
+                    },
+                    onError = { t ->
+                        Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
                     }
-                }
+                )
             },
             modifier = Modifier.padding(horizontal = 18.dp),
             isButtonEnabled = viewModel.canConfirmEdit()

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -35,6 +35,7 @@ fun EditTrainingTimeScreen(
 
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),
+            isActive = true,
             isDaySelected = { trainingTime.days.contains(Day.from(it)) },
             trainingTime = "${trainingTime.asHour()}:${trainingTime.asMinute()} ${trainingTime.asAmpm()}",
             onTimeCardClick = { showTimePickDialog = true },

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeScreen.kt
@@ -13,6 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.sopt.smeem.R
 import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.TrainingTime
@@ -23,11 +27,16 @@ import com.sopt.smeem.util.VerticalSpacer
 
 @Composable
 fun EditTrainingTimeScreen(
+    navController: NavController,
     modifier: Modifier = Modifier,
     trainingTime: TrainingTime,
+    viewModel: EditTrainingTimeViewModel = hiltViewModel()
 ) {
 
+    viewModel.originalTime = trainingTime
+
     var showTimePickDialog by rememberSaveable { mutableStateOf(false) }
+    val selectedDays by viewModel.days.collectAsStateWithLifecycle()
 
     Column(modifier = modifier.fillMaxWidth()) {
 
@@ -36,15 +45,16 @@ fun EditTrainingTimeScreen(
         SmeemAlarmCard(
             modifier = Modifier.padding(horizontal = 19.dp),
             isActive = true,
-            isDaySelected = { trainingTime.days.contains(Day.from(it)) },
+            selectedDays = selectedDays,
             trainingTime = "${trainingTime.asHour()}:${trainingTime.asMinute()} ${trainingTime.asAmpm()}",
             onTimeCardClick = { showTimePickDialog = true },
-            isContentClickable = true
+            isContentClickable = true,
+            onDayClick = { day ->
+                viewModel.toggleDaySelection(day)
+            }
         )
 
-
         Spacer(modifier = Modifier.weight(1f))
-
 
         SmeemButton(
             text = stringResource(R.string.training_time_change_button),
@@ -71,6 +81,7 @@ fun EditTrainingTimeScreen(
 @Composable
 fun PreviewEditTrainingTimeScreen() {
     EditTrainingTimeScreen(
+        navController = rememberNavController(),
         trainingTime = TrainingTime(setOf(Day.MON, Day.THU), 10, 30),
     )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
@@ -61,7 +61,7 @@ class EditTrainingTimeViewModel @Inject constructor(
     fun canConfirmEdit() = _days.value.isNotEmpty() &&
             TrainingTime(_days.value, hour.value, minute.value) != trainingTime.value
 
-    fun sendServer(onError: (Throwable) -> Unit) {
+    fun sendServer(onSuccess: () -> Unit, onError: (Throwable) -> Unit) {
         viewModelScope.launch {
             try {
                 userRepository.editTraining(
@@ -73,6 +73,7 @@ class EditTrainingTimeViewModel @Inject constructor(
                         )
                     )
                 )
+                onSuccess()
             } catch (t: Throwable) {
                 onError(t)
             }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -38,7 +37,6 @@ class EditTrainingTimeViewModel @Inject constructor(
         _days.value = newTrainingTime.days.toMutableSet()
         _hour.value = newTrainingTime.hour
         _minute.value = newTrainingTime.minute
-        Timber.e("initialize: ${_trainingTime.value}")
     }
 
     fun isDaySelected(content: String) = _days.value.contains(Day.from(content))

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/EditTrainingTimeViewModel.kt
@@ -1,6 +1,5 @@
 package com.sopt.smeem.presentation.mypage.setting
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sopt.smeem.domain.model.Day
@@ -27,8 +26,15 @@ class EditTrainingTimeViewModel @Inject constructor(
     // 서버로 보내기 위한 선택시간 저장 변수
     private val _days = MutableStateFlow(originalTime.days.toMutableSet())
     val days: StateFlow<MutableSet<Day>> = _days.asStateFlow()
-    var hour = MutableLiveData<Int>()
-    var minute = MutableLiveData<Int>()
+
+    private val _hour = MutableStateFlow(originalTime.hour)
+    val hour: StateFlow<Int> = _hour.asStateFlow()
+
+    private val _minute = MutableStateFlow(originalTime.minute)
+    val minute: StateFlow<Int> = _minute.asStateFlow()
+
+    private val _trainingTime = MutableStateFlow(originalTime)
+    val trainingTime: StateFlow<TrainingTime> = _trainingTime.asStateFlow()
 
     fun isDaySelected(content: String) = _days.value.contains(Day.from(content))
     fun addDay(content: String) = _days.value.add(Day.from(content))
@@ -42,12 +48,13 @@ class EditTrainingTimeViewModel @Inject constructor(
         }
     }
 
-    fun canConfirmEdit() =
-        _days.value.isNotEmpty() && (TrainingTime(
-            _days.value,
-            hour.value!!,
-            minute.value!!
-        ) != originalTime)
+    fun updateHourMinute(hour: Int, minute: Int) {
+        _hour.value = hour
+        _minute.value = minute
+    }
+
+    fun canConfirmEdit() = _days.value.isNotEmpty() &&
+            TrainingTime(_days.value, hour.value, minute.value) != originalTime
 
     fun sendServer(onError: (Throwable) -> Unit) {
         viewModelScope.launch {
@@ -56,8 +63,8 @@ class EditTrainingTimeViewModel @Inject constructor(
                     Training(
                         trainingTime = TrainingTime(
                             _days.value,
-                            hour.value!!,
-                            minute.value!!
+                            hour.value,
+                            minute.value
                         )
                     )
                 )

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -34,7 +34,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 @Composable
 fun SettingScreen(
     navController: NavController,
-    viewModel: SettingViewModel,
+    viewModel: SettingViewModel = hiltViewModel(),
     modifier: Modifier
 ) {
     val state by viewModel.collectAsState()

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -102,6 +102,7 @@ fun SettingScreen(
 
                 SmeemAlarmCard(
                     modifier = Modifier.padding(horizontal = 19.dp),
+                    isActive = isSwitchChecked,
                     isDaySelected = { selectedTrainingTime.day.contains(Day.from(it)) },
                     onAlarmCardClick = {
                         if (isSwitchChecked) {

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -12,87 +12,125 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.sopt.smeem.domain.dto.MyInfoDto
 import com.sopt.smeem.domain.model.Day
-import com.sopt.smeem.domain.model.TrainingTime
+import com.sopt.smeem.presentation.compose.components.LoadingScreen
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
 import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
 import com.sopt.smeem.presentation.mypage.components.TargetLanguageCard
 import com.sopt.smeem.presentation.mypage.navigation.SettingNavGraph
+import com.sopt.smeem.util.UiState
 import com.sopt.smeem.util.VerticalSpacer
+import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
 fun SettingScreen(
     navController: NavController,
+    viewModel: SettingViewModel,
     modifier: Modifier
 ) {
-
-    // TODO 초기값 서버에서 가져오기
-    val mockNickname = "이태하이"
-    val mockMyPlan = "주 3회 일기 작성하기"
+    val state by viewModel.collectAsState()
     var isSwitchChecked by rememberSaveable { mutableStateOf(true) }
-    val mockDays = setOf(Day.MON, Day.TUE, Day.THU)
-    val mockTrainingTime = TrainingTime(mockDays, 12, 30)
 
-    Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        VerticalSpacer(height = 50.dp)
+    when (val uiState = state.uiState) {
+        is UiState.Loading -> {
+            LoadingScreen()
+        }
 
-        ChangeNicknameCard(
-            nickname = mockNickname,
-            onEditClick = {
-                navController.navigate(SettingNavGraph.ChangeNickname.createRoute(mockNickname))
+        is UiState.Success -> {
+            val response = uiState.data
+            val username = response.username
+            val myPlan = response.trainingPlan?.content
+            val targetLanguage = response.targetLang
+            isSwitchChecked = response.hasPushAlarm
+            val selectedTrainingTime = if (response.trainingTime!!.day.isNotEmpty()) {
+                response.trainingTime
+            } else {
+                MyInfoDto.MyTrainingTime(
+                    setOf(Day.MON, Day.TUE, Day.WED, Day.THU, Day.FRI),
+                    22,
+                    0
+                )
             }
-        )
 
-        VerticalSpacer(height = 28.dp)
+            Column(
+                modifier = modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                VerticalSpacer(height = 50.dp)
 
-        ChangeMyPlanCard(myPlan = mockMyPlan, onEditClick = {
-            navController.navigate(SettingNavGraph.EditTrainingPlan.route)
-        })
+                ChangeNicknameCard(
+                    nickname = username,
+                    onEditClick = {
+                        navController.navigate(
+                            SettingNavGraph.ChangeNickname.createRoute(
+                                username
+                            )
+                        )
+                    }
+                )
 
-        VerticalSpacer(height = 28.dp)
+                VerticalSpacer(height = 28.dp)
 
-        TargetLanguageCard(onEditClick = {})
+                ChangeMyPlanCard(
+                    isPlanSet = myPlan != null,
+                    myPlan = myPlan,
+                    onEditClick = {
+                        navController.navigate(SettingNavGraph.EditTrainingPlan.route)
+                    })
 
-        VerticalSpacer(height = 28.dp)
+                VerticalSpacer(height = 28.dp)
 
-        StudyNotificationCard(
-            checked = isSwitchChecked,
-            onCheckedChange = {
-                isSwitchChecked = it
-                // TODO if 문으로 뷰모델의 changePushAlarm 호출
+                TargetLanguageCard(onEditClick = {})
+
+                VerticalSpacer(height = 28.dp)
+
+                StudyNotificationCard(
+                    checked = isSwitchChecked,
+                    onCheckedChange = {
+                        isSwitchChecked = it
+                        // TODO if 문으로 뷰모델의 changePushAlarm 호출
+                    }
+                )
+
+                VerticalSpacer(height = 10.dp)
+
+                SmeemAlarmCard(
+                    modifier = Modifier.padding(horizontal = 19.dp),
+                    isDaySelected = { selectedTrainingTime.day.contains(Day.from(it)) },
+                    onAlarmCardClick = {
+                        if (isSwitchChecked) {
+                            navController.currentBackStackEntry?.savedStateHandle?.set(
+                                "trainingTime",
+                                selectedTrainingTime
+                            )
+
+                            navController.navigate(
+                                SettingNavGraph.EditTrainingTime.route
+                            )
+                        }
+                    }
+                )
             }
-        )
+        }
 
-        VerticalSpacer(height = 10.dp)
-
-        SmeemAlarmCard(
-            modifier = Modifier.padding(horizontal = 19.dp),
-            isDaySelected = { mockTrainingTime.days.contains(Day.from(it)) },
-            onAlarmCardClick = {
-                if (isSwitchChecked) {
-                    navController.currentBackStackEntry?.savedStateHandle?.set(
-                        "trainingTime",
-                        mockTrainingTime
-                    )
-
-                    navController.navigate(
-                        SettingNavGraph.EditTrainingTime.route
-                    )
-                }
-            }
-        )
+        is UiState.Failure -> {
+            // TODO : 실패 시 처리
+        }
     }
 }
 
 @Preview(showSystemUi = true, showBackground = true)
 @Composable
 fun SettingScreenPreview() {
-    SettingScreen(navController = rememberNavController(), modifier = Modifier)
+    SettingScreen(
+        navController = rememberNavController(),
+        viewModel = hiltViewModel(),
+        modifier = Modifier
+    )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -50,7 +50,7 @@ fun SettingScreen(
             val response = uiState.data
             val username = response.username
             val myPlan = response.trainingPlan?.content
-            val targetLanguage = response.targetLang
+            // val targetLanguage = response.targetLang TODO : 언어 추가시 주석 해제
             val selectedTrainingTime = if (response.trainingTime!!.isSet()) {
                 response.trainingTime
             } else {
@@ -124,7 +124,7 @@ fun SettingScreen(
                 SmeemAlarmCard(
                     modifier = Modifier.padding(horizontal = 19.dp),
                     isActive = isSwitchChecked,
-                    isDaySelected = { selectedTrainingTime.days.contains(Day.from(it)) },
+                    selectedDays = selectedTrainingTime.days.toMutableSet(),
                     onAlarmCardClick = {
                         if (isSwitchChecked) {
                             navController.currentBackStackEntry?.savedStateHandle?.set(

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -125,6 +125,7 @@ fun SettingScreen(
                     modifier = Modifier.padding(horizontal = 19.dp),
                     isActive = isSwitchChecked,
                     selectedDays = selectedTrainingTime.days.toMutableSet(),
+                    trainingTime = selectedTrainingTime.asText(),
                     onAlarmCardClick = {
                         if (isSwitchChecked) {
                             navController.currentBackStackEntry?.savedStateHandle?.set(

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingSideEffect.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingSideEffect.kt
@@ -1,0 +1,5 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+sealed class SettingSideEffect {
+    data class ShowToast(val message: String) : SettingSideEffect()
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingState.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingState.kt
@@ -1,0 +1,8 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+import com.sopt.smeem.domain.dto.MyInfoDto
+import com.sopt.smeem.util.UiState
+
+data class SettingState(
+    val uiState: UiState<MyInfoDto> = UiState.Loading,
+)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingViewModel.kt
@@ -2,6 +2,7 @@ package com.sopt.smeem.presentation.mypage.setting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sopt.smeem.domain.model.PushAlarm
 import com.sopt.smeem.domain.repository.UserRepository
 import com.sopt.smeem.util.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -50,6 +51,16 @@ class SettingViewModel @Inject constructor(
                         state.copy(uiState = UiState.Failure)
                     }
                 }
+                onError(t)
+            }
+        }
+    }
+
+    fun changePushAlarm(hasAlarm: Boolean, onError: (Throwable) -> Unit) {
+        viewModelScope.launch {
+            try {
+                userRepository.editPushAlarm(PushAlarm(hasAlarm = hasAlarm))
+            } catch (t: Throwable) {
                 onError(t)
             }
         }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingViewModel.kt
@@ -1,0 +1,58 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sopt.smeem.domain.repository.UserRepository
+import com.sopt.smeem.util.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingViewModel @Inject constructor(
+    private val userRepository: UserRepository
+) : ContainerHost<SettingState, SettingSideEffect>, ViewModel() {
+
+    override val container = container<SettingState, SettingSideEffect>(SettingState())
+
+    init {
+        fetchSettingData(onError = {
+            intent {
+                postSideEffect(SettingSideEffect.ShowToast("알 수 없는 오류가 발생했습니다."))
+            }
+        })
+    }
+
+    private fun fetchSettingData(onError: (Throwable) -> Unit) {
+        viewModelScope.launch {
+            intent {
+                reduce {
+                    state.copy(uiState = UiState.Loading)
+                }
+            }
+
+            try {
+                val response = userRepository.getMyInfo().data()
+
+                intent {
+                    reduce {
+                        state.copy(uiState = UiState.Success(response))
+                    }
+                }
+            } catch (t: Throwable) {
+                intent {
+                    reduce {
+                        state.copy(uiState = UiState.Failure)
+                    }
+                }
+                onError(t)
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/sopt/smeem/util/UiState.kt
+++ b/app/src/main/java/com/sopt/smeem/util/UiState.kt
@@ -1,0 +1,11 @@
+package com.sopt.smeem.util
+
+sealed interface UiState<out T> {
+    data object Loading : UiState<Nothing>
+
+    data class Success<T>(
+        val data: T,
+    ) : UiState<T>
+
+    data object Failure : UiState<Nothing>
+}

--- a/app/src/main/res/layout/activity_edit_training_time.xml
+++ b/app/src/main/res/layout/activity_edit_training_time.xml
@@ -9,7 +9,8 @@
 
         <variable
             name="vm"
-            type="com.sopt.smeem.presentation.mypage.EditTrainingTimeViewModel" />
+            type="com.sopt.smeem.presentation.mypage.setting.EditTrainingTimeViewModel" />
+
         <variable
             name="trainingTime"
             type="com.sopt.smeem.domain.model.TrainingTime" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,4 +116,5 @@
     <string name="edit_training_plan_button">완료</string>
     <string name="no_plan_title">아직 플랜이 없어요!</string>
     <string name="no_plan_navigate_description">플랜 설정하러 가기</string>
+    <string name="set_my_plan">플랜 설정하기</string>
 </resources>


### PR DESCRIPTION
- closed #258
- closed #264 
- closed #276 

## *⛳️ Work Description*
- members/me api 연동
- myplan null 일 시 컴포넌트 변경
- switch 상태에 따라 pushalarm 서버 요청 상태 변경 및 기존 녹이기/얼리기 로직 반영
- SmeemAlarmCard day 터치, 알림 시간 터치 시 로직 반영 
- 완료 버튼 눌렀을 때 success인 경우에만 다시 SettingScreen으로 이동해서 최신 값 반영 
- EditTrainingTimeScreen에서 전달 받은 값을 뷰모델에 전달하여 업데이트 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/Team-Smeme/smeem-aos/assets/98825364/358afa65-9325-4648-b817-12ab861b620b


## *📢 To Reviewers*
- 기존 로직에서 빠뜨린거 있으면 꼭 말씀해주세요~
- 닉네임 변경 api와 트레이닝 플랜 변경 api 연동 작업은 이 pr 머지되면 바로 하겠습니다~
