### PR TITLE
[마이페이지] 닉네임 변경 API 연동 

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/navigation/MyPageNavHost.kt
@@ -125,6 +125,7 @@ private fun NavGraphBuilder.addSetting(navController: NavController, modifier: M
             val nickname = backStackEntry.arguments?.getString("nickname") ?: ""
 
             ChangeNicknameScreen(
+                navController = navController,
                 modifier = modifier,
                 nickname = nickname
             )

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNickNameViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNickNameViewModel.kt
@@ -6,6 +6,7 @@ import com.sopt.smeem.Anonymous
 import com.sopt.smeem.domain.repository.LoginRepository
 import com.sopt.smeem.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -48,6 +49,8 @@ class ChangeNickNameViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 userRepository.modifyUsername(nickname)
+                // 키보드가 완전히 내려지기 전까지 기다리는 시간 TODO: 상태 감지
+                delay(800)
                 intent {
                     postSideEffect(ChangeNicknameSideEffect.NavigateToSettingScreen)
                 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNickNameViewModel.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNickNameViewModel.kt
@@ -1,0 +1,73 @@
+package com.sopt.smeem.presentation.mypage.setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sopt.smeem.Anonymous
+import com.sopt.smeem.domain.repository.LoginRepository
+import com.sopt.smeem.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class ChangeNickNameViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    @Anonymous private val loginRepository: LoginRepository
+) : ContainerHost<ChangeNicknameUiState, ChangeNicknameSideEffect>, ViewModel() {
+
+    override val container =
+        container<ChangeNicknameUiState, ChangeNicknameSideEffect>(ChangeNicknameUiState())
+
+    fun checkNicknameDuplicated(nickname: String) {
+        if (nickname.isNotBlank()) {
+            intent {
+                reduce {
+                    state.copy(nickname = nickname)
+                }
+            }
+
+            viewModelScope.launch {
+                try {
+                    loginRepository.checkNicknameDuplicated(nickname)
+                        .run { intent { reduce { state.copy(isDuplicated = data()) } } }
+                } catch (t: Throwable) {
+                    intent {
+                        postSideEffect(ChangeNicknameSideEffect.ShowErrorToast(t.message ?: ""))
+                    }
+                }
+            }
+        }
+    }
+
+    fun changeNickname(nickname: String) {
+        viewModelScope.launch {
+            try {
+                userRepository.modifyUsername(nickname)
+                intent {
+                    postSideEffect(ChangeNicknameSideEffect.NavigateToSettingScreen)
+                }
+            } catch (t: Throwable) {
+                intent {
+                    postSideEffect(ChangeNicknameSideEffect.ShowErrorToast(t.message ?: ""))
+                }
+            }
+        }
+    }
+
+}
+
+
+data class ChangeNicknameUiState(
+    val nickname: String = "",
+    val isDuplicated: Boolean = false
+)
+
+sealed class ChangeNicknameSideEffect {
+    data class ShowErrorToast(val message: String) : ChangeNicknameSideEffect()
+    data object NavigateToSettingScreen : ChangeNicknameSideEffect()
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -54,6 +55,7 @@ fun ChangeNicknameScreen(
     val context = LocalContext.current
 
     val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     var textFieldState by remember { mutableStateOf(TextFieldValue(text = nickname)) }
 
@@ -118,7 +120,11 @@ fun ChangeNicknameScreen(
 
         SmeemButton(
             text = stringResource(id = R.string.my_page_change_nickname_button),
-            onClick = { viewModel.changeNickname(textFieldState.text) },
+            onClick = {
+                focusManager.clearFocus()
+                keyboardController?.hide()
+                viewModel.changeNickname(textFieldState.text)
+            },
             modifier = Modifier.padding(horizontal = 18.dp),
             isButtonEnabled = textFieldState.text.length
                     in NICKNAME_MIN_LENGTH..NICKNAME_MAX_LENGTH
@@ -145,6 +151,12 @@ fun ChangeNicknameScreen(
                         saveState = false
                     }
                 }
+
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.my_page_edit_done_message),
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
     }
@@ -154,5 +166,8 @@ fun ChangeNicknameScreen(
 @Composable
 @Preview(showBackground = true, showSystemUi = true)
 fun ChangeNicknameScreenPreview() {
-    ChangeNicknameScreen(navController = rememberNavController(), nickname = "이태하이")
+    ChangeNicknameScreen(
+        navController = rememberNavController(),
+        nickname = "이태하이"
+    )
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
@@ -29,21 +29,21 @@ import com.sopt.smeem.presentation.compose.components.SmeemButton
 import com.sopt.smeem.presentation.compose.components.SmeemTextField
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.gray400
+import com.sopt.smeem.presentation.compose.theme.point
 import com.sopt.smeem.presentation.mypage.NICKNAME_MAX_LENGTH
 import com.sopt.smeem.presentation.mypage.NICKNAME_MIN_LENGTH
-import com.sopt.smeem.util.HorizontalSpacer
 import com.sopt.smeem.util.VerticalSpacer
 import com.sopt.smeem.util.addFocusCleaner
 
 @Composable
 fun ChangeNicknameScreen(
     modifier: Modifier = Modifier,
-    nickname: String
+    nickname: String,
+    isDuplicated: Boolean = false
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
     var textFieldState by remember { mutableStateOf(TextFieldValue(text = nickname)) }
-
 
     LaunchedEffect(key1 = Unit) {
         focusRequester.requestFocus()
@@ -79,7 +79,19 @@ fun ChangeNicknameScreen(
 
         VerticalSpacer(height = 10.dp)
 
-        Row(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 18.dp)
+        ) {
+            if (isDuplicated) {
+                Text(
+                    text = "이미 사용 중인 닉네임이에요 :(",
+                    style = Typography.labelSmall,
+                    color = point,
+                )
+            }
+
             Spacer(modifier = Modifier.weight(1f))
 
             Text(
@@ -87,8 +99,6 @@ fun ChangeNicknameScreen(
                 style = Typography.labelSmall,
                 color = gray400,
             )
-
-            HorizontalSpacer(width = 18.dp)
         }
 
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/ChangeNicknameScreen.kt
@@ -86,7 +86,7 @@ fun ChangeNicknameScreen(
         ) {
             if (isDuplicated) {
                 Text(
-                    text = "이미 사용 중인 닉네임이에요 :(",
+                    text = stringResource(id = R.string.entrance_nickname_duplicated),
                     style = Typography.labelSmall,
                     color = point,
                 )
@@ -109,7 +109,7 @@ fun ChangeNicknameScreen(
             onClick = { /*TODO*/ },
             modifier = Modifier.padding(horizontal = 18.dp),
             isButtonEnabled = textFieldState.text.length
-                    in NICKNAME_MIN_LENGTH..NICKNAME_MAX_LENGTH
+                    in NICKNAME_MIN_LENGTH..NICKNAME_MAX_LENGTH && textFieldState.text != nickname
         )
 
         VerticalSpacer(height = 10.dp)

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -30,6 +30,7 @@ import com.sopt.smeem.presentation.mypage.navigation.SettingNavGraph
 import com.sopt.smeem.util.UiState
 import com.sopt.smeem.util.VerticalSpacer
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun SettingScreen(
@@ -144,6 +145,14 @@ fun SettingScreen(
 
         is UiState.Failure -> {
             // TODO : 실패 시 처리
+        }
+    }
+
+    viewModel.collectSideEffect {
+        when (it) {
+            is SettingSideEffect.ShowToast -> {
+                Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+            }
         }
     }
 }


### PR DESCRIPTION
- closed #259 

## *⛳️ Work Description*
- 조건에 따라 버튼 활성화 조정했습니다.
- 중복 검사 API와 닉넴수정 API 연동했습니다.
- 키보드가 완전히 내려간 후 Toast 보내는 로직을 단순히 delay를 주었습니다 추후 수정하겠습니다!
- Orbit 라이브러리 활용했습니다. 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/Team-Smeme/smeem-aos/assets/98825364/473ede19-9679-49d8-91b3-e44946ca7a9a

## *📢 To Reviewers*
- 각자 환경에서 잘 되는지 확인 부탁요
- 이전 pr 머지되면 rebase 하겠습니다
