### PR TITLE
배지 다이얼로그 관련 이슈 해결

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/home/BadgeDialogFragment.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/BadgeDialogFragment.kt
@@ -12,8 +12,8 @@ import com.sopt.smeem.R
 import com.sopt.smeem.databinding.DialogBadgeBinding
 import com.sopt.smeem.event.AmplitudeEventType
 import com.sopt.smeem.presentation.EventVM
-import com.sopt.smeem.presentation.mypage.MyBadgesActivity
 import com.sopt.smeem.presentation.mypage.MyBadgesActivity.Companion.ENTER_MY_BADGES_FROM
+import com.sopt.smeem.presentation.mypage.TempMyPageActivity
 import com.sopt.smeem.util.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -60,7 +60,7 @@ class BadgeDialogFragment : DialogFragment() {
                 eventVm.sendEvent(AmplitudeEventType.WELCOME_MORE_CLICK)
             }
             dismiss()
-            Intent(requireContext(), MyBadgesActivity::class.java)
+            Intent(requireContext(), TempMyPageActivity::class.java)
                 .apply {
                     putExtra(ENTER_MY_BADGES_FROM, FROM_BADGE_DIALOG)
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -15,7 +15,7 @@ import com.sopt.smeem.R
 import com.sopt.smeem.data.SmeemDataStore.RECENT_DIARY_DATE
 import com.sopt.smeem.data.SmeemDataStore.dataStore
 import com.sopt.smeem.databinding.ActivityHomeBinding
-import com.sopt.smeem.domain.model.RetrievedBadge
+import com.sopt.smeem.domain.dto.RetrievedBadgeDto
 import com.sopt.smeem.event.AmplitudeEventType
 import com.sopt.smeem.presentation.BindingActivity
 import com.sopt.smeem.presentation.EventVM
@@ -125,7 +125,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
 
     private fun showBadgeDialog() {
         val retrievedBadge =
-            intent.getSerializableExtra(RETRIEVED_BADGE_DTO) as List<RetrievedBadge>?
+            intent.getSerializableExtra(RETRIEVED_BADGE_DTO) as List<RetrievedBadgeDto>?
                 ?: emptyList()
         if (retrievedBadge.isNotEmpty()) {
             val badgeList = retrievedBadge.asReversed()

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -19,6 +19,9 @@ import com.sopt.smeem.domain.model.RetrievedBadge
 import com.sopt.smeem.event.AmplitudeEventType
 import com.sopt.smeem.presentation.BindingActivity
 import com.sopt.smeem.presentation.EventVM
+import com.sopt.smeem.presentation.IntentConstants.DIARY_ID
+import com.sopt.smeem.presentation.IntentConstants.RETRIEVED_BADGE_DTO
+import com.sopt.smeem.presentation.IntentConstants.SNACKBAR_TEXT
 import com.sopt.smeem.presentation.compose.theme.SmeemTheme
 import com.sopt.smeem.presentation.detail.DiaryDetailActivity
 import com.sopt.smeem.presentation.home.WritingBottomSheet.Companion.TAG
@@ -113,16 +116,16 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
     }
 
     private fun showDiaryCompleted() {
-        val msg = intent.getStringExtra("snackbarText")
+        val msg = intent.getStringExtra(SNACKBAR_TEXT)
         if (msg != null) {
             DefaultSnackBar.make(binding.root, msg).show()
-            intent.removeExtra("snackbarText")
+            intent.removeExtra(SNACKBAR_TEXT)
         }
     }
 
     private fun showBadgeDialog() {
         val retrievedBadge =
-            intent.getSerializableExtra("retrievedBadge") as List<RetrievedBadge>?
+            intent.getSerializableExtra(RETRIEVED_BADGE_DTO) as List<RetrievedBadge>?
                 ?: emptyList()
         if (retrievedBadge.isNotEmpty()) {
             val badgeList = retrievedBadge.asReversed()
@@ -141,7 +144,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                     if (isFirstBadge) isFirstBadge = false
                 }
             }
-            intent.removeExtra("retrievedBadge")
+            intent.removeExtra(RETRIEVED_BADGE_DTO)
         }
     }
 
@@ -167,7 +170,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
     private fun setInitListener() {
         binding.clDiaryList.setOnSingleClickListener {
             Intent(this, DiaryDetailActivity::class.java).apply {
-                putExtra("diaryId", homeViewModel.diaryList.value?.id)
+                putExtra(DIARY_ID, homeViewModel.diaryList.value?.id)
             }.run(::startActivity)
         }
     }

--- a/app/src/main/java/com/sopt/smeem/presentation/join/JoinWithAgreementActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/join/JoinWithAgreementActivity.kt
@@ -2,16 +2,15 @@ package com.sopt.smeem.presentation.join
 
 import android.content.Intent
 import android.widget.Toast
-import android.window.OnBackInvokedDispatcher
 import androidx.activity.viewModels
 import com.google.android.material.button.MaterialButton
 import com.sopt.smeem.R
 import com.sopt.smeem.SmeemErrorCode
 import com.sopt.smeem.SmeemException
 import com.sopt.smeem.databinding.ActivityJoinAgreementBinding
-import com.sopt.smeem.description
 import com.sopt.smeem.domain.model.RetrievedBadge
 import com.sopt.smeem.presentation.BindingActivity
+import com.sopt.smeem.presentation.IntentConstants.RETRIEVED_BADGE_DTO
 import com.sopt.smeem.presentation.agreement.AgreementViewActivity
 import com.sopt.smeem.presentation.home.HomeActivity
 import com.sopt.smeem.presentation.join.JoinConstant.ACCESS_TOKEN
@@ -33,8 +32,12 @@ class JoinWithAgreementActivity :
     private lateinit var refreshToken: String
 
     override fun constructLayout() {
-        accessToken = intent.getStringExtra(ACCESS_TOKEN) ?: throw SmeemException(SmeemErrorCode.SYSTEM_ERROR, "토큰이 정상적으로 전달되지 않았습니다.")
-        refreshToken = intent.getStringExtra(REFRESH_TOKEN) ?: throw SmeemException(SmeemErrorCode.SYSTEM_ERROR, "토큰이 정상적으로 전달되지 않았습니다.")
+        accessToken = intent.getStringExtra(ACCESS_TOKEN) ?: throw SmeemException(
+            SmeemErrorCode.SYSTEM_ERROR,
+            "토큰이 정상적으로 전달되지 않았습니다."
+        )
+        refreshToken = intent.getStringExtra(REFRESH_TOKEN)
+            ?: throw SmeemException(SmeemErrorCode.SYSTEM_ERROR, "토큰이 정상적으로 전달되지 않았습니다.")
 
 
         EntranceSelection.SERVICE.id = binding.btnEntranceAgreementService.id
@@ -144,7 +147,11 @@ class JoinWithAgreementActivity :
         }
     }
 
-    private fun sendServer(nickname: String, selected: Set<EntranceSelection>, accessToken: String) {
+    private fun sendServer(
+        nickname: String,
+        selected: Set<EntranceSelection>,
+        accessToken: String
+    ) {
         vm.registerNicknameAndAcceptance(
             nickname,
             selected,
@@ -162,12 +169,14 @@ class JoinWithAgreementActivity :
                 true -> {
                     vm.saveTokenInLocal(accessToken, refreshToken)
                     Intent(this, HomeActivity::class.java).apply {
-                        putExtra("retrievedBadge", listOf(
-                            RetrievedBadge(
-                                "웰컴 배지",
-                                "https://github.com/Team-Smeme/Smeme-plan/assets/120551217/6b3319cb-4c6f-4bf2-86dd-7576a44b46c7"
-                            )
-                        ) as Serializable)
+                        putExtra(
+                            RETRIEVED_BADGE_DTO, listOf(
+                                RetrievedBadge(
+                                    "웰컴 배지",
+                                    "https://github.com/Team-Smeme/Smeme-plan/assets/120551217/6b3319cb-4c6f-4bf2-86dd-7576a44b46c7"
+                                )
+                            ) as Serializable
+                        )
                     }.run(::startActivity)
                     finishAffinity()
                 }

--- a/app/src/main/java/com/sopt/smeem/presentation/join/JoinWithAgreementActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/join/JoinWithAgreementActivity.kt
@@ -8,7 +8,7 @@ import com.sopt.smeem.R
 import com.sopt.smeem.SmeemErrorCode
 import com.sopt.smeem.SmeemException
 import com.sopt.smeem.databinding.ActivityJoinAgreementBinding
-import com.sopt.smeem.domain.model.RetrievedBadge
+import com.sopt.smeem.domain.dto.RetrievedBadgeDto
 import com.sopt.smeem.presentation.BindingActivity
 import com.sopt.smeem.presentation.IntentConstants.RETRIEVED_BADGE_DTO
 import com.sopt.smeem.presentation.agreement.AgreementViewActivity
@@ -171,7 +171,7 @@ class JoinWithAgreementActivity :
                     Intent(this, HomeActivity::class.java).apply {
                         putExtra(
                             RETRIEVED_BADGE_DTO, listOf(
-                                RetrievedBadge(
+                                RetrievedBadgeDto(
                                     "웰컴 배지",
                                     "https://github.com/Team-Smeme/Smeme-plan/assets/120551217/6b3319cb-4c6f-4bf2-86dd-7576a44b46c7"
                                 )


### PR DESCRIPTION
- closed #288 

## *⛳️ Work Description*
- 웰컴배지 및 일기 작성 후 넘겨지는 intent name을 수정했습니다
- HomeActivity에서 intent값 받는 로직 수정했습니다
- 배지 모두보기 클릭시, 성과요약 화면으로 이동하도록 변경했습니다

## *📸 Screenshot*
https://github.com/Team-Smeme/smeem-aos/assets/74162198/e1447da5-9c7d-4859-ae70-8254fd20a0e4

## *📢 To Reviewers*
- 이번 스프린트 작업하면서 쓰지 않게된 파일은 지우는걸 고려해보면 좋을 것 같아요!
- 서버에서는 '학습 목표 수정' 배지 정보도 넘어오는데, 기획 정책상에는 (+ 피그마) 없어서 목록에서 지우려고 합니다. 괜찮으면 이 브랜치에 푸시 함 올리겠습니다
