### PR TITLE
[QA] 다이얼로그 크기 기기 대응 

### DIFF
--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/SmeemTimePickerDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,11 +17,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.sopt.smeem.presentation.compose.theme.Typography
 import com.sopt.smeem.presentation.compose.theme.black
 import com.sopt.smeem.presentation.compose.theme.point
@@ -39,8 +38,6 @@ fun SmeemTimePickerDialog(
     initialMinute: Int,
     modifier: Modifier = Modifier,
 ) {
-
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
     val timeOfDay = remember { listOf("오전", "오후") }
     val hour = remember { (1..12).map { it.toString() } }
@@ -60,11 +57,16 @@ fun SmeemTimePickerDialog(
         if (selectedHour == 12) 0 else selectedHour
     }
 
-    Dialog(onDismissRequest = onDismissRequest) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
+    ) {
         Surface(
             modifier = modifier
                 .fillMaxWidth()
-                .width(screenWidth - 36.dp)
+                .padding(horizontal = 18.dp)
                 .wrapContentHeight(),
             shape = RoundedCornerShape(10.dp),
             color = white


### PR DESCRIPTION
- closed #291 

## *⛳️ Work Description*
- dialog 속성 중 usePlatformDefaultWidth 를 false로 해제하여 어떠한 기기에서라도 같은 padding을 가지게 만듦

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
특정 DPI에서는 아래와 같이 dialog 좌우 간격이 더 컸으나 해당 작업으로 고침
<img src="https://github.com/Team-Smeme/smeem-aos/assets/98825364/5e824ca8-8893-4eba-bda2-10e779bde08a" width=270 />



