### PR TITLE
[Home] Firebase remote config 연결 및 Banner UI 로직 구현 

### DIFF
--- a/app/src/main/java/com/sopt/smeem/data/SmeemDataStore.kt
+++ b/app/src/main/java/com/sopt/smeem/data/SmeemDataStore.kt
@@ -3,6 +3,8 @@ package com.sopt.smeem.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 
@@ -10,4 +12,6 @@ object SmeemDataStore {
     val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "storage")
 
     val RECENT_DIARY_DATE = stringPreferencesKey("recent_diary_date")
+    val BANNER_CLOSED = booleanPreferencesKey("banner_closed")
+    val BANNER_VERSION = intPreferencesKey("banner_version")
 }

--- a/app/src/main/java/com/sopt/smeem/data/repository/LocalRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/smeem/data/repository/LocalRepositoryImpl.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.sopt.smeem.data.SmeemDataStore.dataStore
 import com.sopt.smeem.domain.common.SmeemErrorCode
@@ -14,6 +15,7 @@ import com.sopt.smeem.domain.common.SmeemException
 import com.sopt.smeem.domain.model.Authentication
 import com.sopt.smeem.domain.model.LocalStatus
 import com.sopt.smeem.domain.repository.LocalRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -21,110 +23,146 @@ import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
 
-class LocalRepositoryImpl @Inject constructor(
-    private val context: Context
-) : LocalRepository {
-
-    override suspend fun setStringValue(key: Preferences.Key<String>, value: String) {
-        context.dataStore.edit { storage -> storage[key] = value }
-    }
-
-    override suspend fun remove(key: Preferences.Key<String>) {
-        context.dataStore.edit { storage -> storage.remove(key) }
-    }
-
-    /**
-     * LocalStorage 로 부터 Authentication 추출
-     * 없을 경우, null 응답
-     * (already cached on DataStore Layer)
-     */
-    override suspend fun getAuthentication(): Authentication {
-        return context.dataStore.data
-            .catch { e: Throwable ->
-                Log.e(
-                    "dataStore_auth",
-                    "로컬스토리지(dataStore) 에 접근해 Authentication 정보를 가져오는 도중 오류가 발생했습니다."
-                )
-                emit(emptyPreferences())
-            }
-            .map { preferences: Preferences ->
-                Authentication(
-                    accessToken = preferences[API_ACCESS_TOKEN] ?: throw SmeemException(
-                        SmeemErrorCode.UNAUTHORIZED,
-                        "인증이 필요합니다."
-                    ),
-                    refreshToken = preferences[API_REFRESH_TOKEN] ?: throw SmeemException(
-                        SmeemErrorCode.UNAUTHORIZED,
-                        "인증이 필요합니다."
-                    )
-                )
-            }.first()
-    }
-
-    override suspend fun setAuthentication(authentication: Authentication) {
-        try {
-            context.dataStore.edit { mutablePreferences: MutablePreferences ->
-                mutablePreferences[API_ACCESS_TOKEN] =
-                    requireNotNull(authentication.accessToken) { "NPE when register authentication with accessToken" }
-                mutablePreferences[API_REFRESH_TOKEN] =
-                    requireNotNull(authentication.accessToken) { "NPE when register authentication with refreshToken" }
-            }
-        } catch (e: IOException) {
-            throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
-        } catch (e: IllegalArgumentException) {
-            throw SmeemException(
-                errorCode = SmeemErrorCode.SYSTEM_ERROR,
-                logMessage = "token 값 저장 중, null 로 접근하였습니다. (authentication = $authentication)"
-            )
+class LocalRepositoryImpl
+    @Inject
+    constructor(
+        private val context: Context,
+    ) : LocalRepository {
+        override suspend fun setStringValue(
+            key: Preferences.Key<String>,
+            value: String,
+        ) {
+            context.dataStore.edit { storage -> storage[key] = value }
         }
-    }
 
-    /**
-     * LocalStorage 에 accessToken 이 저장되었는지 확인
-     */
-    override suspend fun isAuthenticated(): Boolean {
-        return context.dataStore.data
-            .catch { emit(emptyPreferences()) }
-            .map { preferences: Preferences -> preferences[API_ACCESS_TOKEN] }
-            .firstOrNull() != null
-    }
+        override suspend fun setBooleanValue(
+            key: Preferences.Key<Boolean>,
+            value: Boolean,
+        ) {
+            context.dataStore.edit { storage -> storage[key] = value }
+        }
 
-    override suspend fun saveStatus(localStatus: LocalStatus, value: Any?) {
-        try {
-            when (localStatus) {
-                LocalStatus.RANDOM_TOPIC_TOOL_TIP -> {
-                    context.dataStore.edit { mutablePreferences: MutablePreferences ->
-                        mutablePreferences[RANDOM_TOPIC_TOOL_TIP_SWITCH] = false // make it off
+        override suspend fun getBooleanValue(key: String): Boolean {
+            val preferences = context.dataStore.data.first()
+            return preferences[booleanPreferencesKey(key)] ?: false
+        }
+
+        override fun getBooleanFlow(key: String): Flow<Boolean> =
+            context.dataStore.data.map { preferences ->
+                preferences[booleanPreferencesKey(key)] ?: false
+            }
+
+        override suspend fun setIntValue(
+            key: Preferences.Key<Int>,
+            value: Int,
+        ) {
+            context.dataStore.edit { storage -> storage[key] = value }
+        }
+
+        override suspend fun getIntValue(key: String): Int {
+            val preferences = context.dataStore.data.first()
+            return preferences[intPreferencesKey(key)] ?: 0
+        }
+
+        override suspend fun remove(key: Preferences.Key<String>) {
+            context.dataStore.edit { storage -> storage.remove(key) }
+        }
+
+        /**
+         * LocalStorage 로 부터 Authentication 추출
+         * 없을 경우, null 응답
+         * (already cached on DataStore Layer)
+         */
+        override suspend fun getAuthentication(): Authentication =
+            context.dataStore.data
+                .catch { e: Throwable ->
+                    Log.e(
+                        "dataStore_auth",
+                        "로컬스토리지(dataStore) 에 접근해 Authentication 정보를 가져오는 도중 오류가 발생했습니다.",
+                    )
+                    emit(emptyPreferences())
+                }.map { preferences: Preferences ->
+                    Authentication(
+                        accessToken =
+                            preferences[API_ACCESS_TOKEN] ?: throw SmeemException(
+                                SmeemErrorCode.UNAUTHORIZED,
+                                "인증이 필요합니다.",
+                            ),
+                        refreshToken =
+                            preferences[API_REFRESH_TOKEN] ?: throw SmeemException(
+                                SmeemErrorCode.UNAUTHORIZED,
+                                "인증이 필요합니다.",
+                            ),
+                    )
+                }.first()
+
+        override suspend fun setAuthentication(authentication: Authentication) {
+            try {
+                context.dataStore.edit { mutablePreferences: MutablePreferences ->
+                    mutablePreferences[API_ACCESS_TOKEN] =
+                        requireNotNull(authentication.accessToken) { "NPE when register authentication with accessToken" }
+                    mutablePreferences[API_REFRESH_TOKEN] =
+                        requireNotNull(authentication.accessToken) { "NPE when register authentication with refreshToken" }
+                }
+            } catch (e: IOException) {
+                throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
+            } catch (e: IllegalArgumentException) {
+                throw SmeemException(
+                    errorCode = SmeemErrorCode.SYSTEM_ERROR,
+                    logMessage = "token 값 저장 중, null 로 접근하였습니다. (authentication = $authentication)",
+                )
+            }
+        }
+
+        /**
+         * LocalStorage 에 accessToken 이 저장되었는지 확인
+         */
+        override suspend fun isAuthenticated(): Boolean =
+            context.dataStore.data
+                .catch { emit(emptyPreferences()) }
+                .map { preferences: Preferences -> preferences[API_ACCESS_TOKEN] }
+                .firstOrNull() != null
+
+        override suspend fun saveStatus(
+            localStatus: LocalStatus,
+            value: Any?,
+        ) {
+            try {
+                when (localStatus) {
+                    LocalStatus.RANDOM_TOPIC_TOOL_TIP -> {
+                        context.dataStore.edit { mutablePreferences: MutablePreferences ->
+                            mutablePreferences[RANDOM_TOPIC_TOOL_TIP_SWITCH] = false // make it off
+                        }
                     }
                 }
-            }
-        } catch (t: Throwable) {
-            throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
-        }
-    }
-
-    override suspend fun checkStatus(localStatus: LocalStatus): Boolean = context.dataStore.data
-        .catch { emit(emptyPreferences()) }
-        .map { preferences: Preferences ->
-            when (localStatus) {
-                LocalStatus.RANDOM_TOPIC_TOOL_TIP -> preferences[RANDOM_TOPIC_TOOL_TIP_SWITCH]
-                    ?: true // 최초에는 킨 상태
+            } catch (t: Throwable) {
+                throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
             }
         }
-        .first()
 
-    override suspend fun clear() {
-        try {
-            context.dataStore.edit { preferences -> preferences.clear() }
-        } catch (t: Throwable) {
-            throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
+        override suspend fun checkStatus(localStatus: LocalStatus): Boolean =
+            context.dataStore.data
+                .catch { emit(emptyPreferences()) }
+                .map { preferences: Preferences ->
+                    when (localStatus) {
+                        LocalStatus.RANDOM_TOPIC_TOOL_TIP ->
+                            preferences[RANDOM_TOPIC_TOOL_TIP_SWITCH]
+                                ?: true // 최초에는 킨 상태
+                    }
+                }.first()
+
+        override suspend fun clear() {
+            try {
+                context.dataStore.edit { preferences -> preferences.clear() }
+            } catch (t: Throwable) {
+                throw SmeemException(errorCode = SmeemErrorCode.SYSTEM_ERROR)
+            }
+        }
+
+        companion object {
+            private val API_ACCESS_TOKEN = stringPreferencesKey("api_access_token")
+            private val API_REFRESH_TOKEN = stringPreferencesKey("api_refresh_token")
+            private val RANDOM_TOPIC_TOOL_TIP_SWITCH =
+                booleanPreferencesKey(LocalStatus.RANDOM_TOPIC_TOOL_TIP.name)
         }
     }
-
-    companion object {
-        private val API_ACCESS_TOKEN = stringPreferencesKey("api_access_token")
-        private val API_REFRESH_TOKEN = stringPreferencesKey("api_refresh_token")
-        private val RANDOM_TOPIC_TOOL_TIP_SWITCH =
-            booleanPreferencesKey(LocalStatus.RANDOM_TOPIC_TOOL_TIP.name)
-    }
-}

--- a/app/src/main/java/com/sopt/smeem/domain/repository/LocalRepository.kt
+++ b/app/src/main/java/com/sopt/smeem/domain/repository/LocalRepository.kt
@@ -3,16 +3,44 @@ package com.sopt.smeem.domain.repository
 import androidx.datastore.preferences.core.Preferences
 import com.sopt.smeem.domain.model.Authentication
 import com.sopt.smeem.domain.model.LocalStatus
+import kotlinx.coroutines.flow.Flow
 
 interface LocalRepository {
-    suspend fun setStringValue(key: Preferences.Key<String>, value: String)
+    suspend fun setStringValue(
+        key: Preferences.Key<String>,
+        value: String,
+    )
+
+    suspend fun setBooleanValue(
+        key: Preferences.Key<Boolean>,
+        value: Boolean,
+    )
+
+    suspend fun getBooleanValue(key: String): Boolean
+
+    fun getBooleanFlow(key: String): Flow<Boolean>
+
+    suspend fun setIntValue(
+        key: Preferences.Key<Int>,
+        value: Int,
+    )
+
+    suspend fun getIntValue(key: String): Int
+
     suspend fun remove(key: Preferences.Key<String>)
+
     suspend fun getAuthentication(): Authentication
+
     suspend fun setAuthentication(authentication: Authentication)
+
     suspend fun isAuthenticated(): Boolean
 
-    suspend fun saveStatus(localStatus: LocalStatus, value: Any? = null)
+    suspend fun saveStatus(
+        localStatus: LocalStatus,
+        value: Any? = null,
+    )
 
     suspend fun checkStatus(localStatus: LocalStatus): Boolean
+
     suspend fun clear()
 }

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/Banner.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/Banner.kt
@@ -1,0 +1,91 @@
+package com.sopt.smeem.presentation.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.smeem.R
+import com.sopt.smeem.presentation.compose.theme.Typography
+import com.sopt.smeem.presentation.compose.theme.black
+import com.sopt.smeem.presentation.compose.theme.gray100
+import com.sopt.smeem.presentation.compose.theme.gray200
+import com.sopt.smeem.util.HorizontalSpacer
+import com.sopt.smeem.util.VerticalSpacer
+
+@Composable
+fun Banner(
+    title: String,
+    content: String,
+    onBannerClick: () -> Unit,
+    onBannerClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .background(gray100, shape = RoundedCornerShape(10.dp))
+            .clip(RoundedCornerShape(10.dp))
+            .clickable { onBannerClick() }
+        ,
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Column(
+                modifier =
+                    Modifier
+                        .padding(top = 20.dp, bottom = 20.dp, start = 14.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = Typography.titleLarge,
+                    color = black,
+                )
+
+                VerticalSpacer(height = 4.dp)
+
+                Text(
+                    text = content,
+                    style = Typography.labelLarge,
+                    color = black,
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                painter = painterResource(id = R.drawable.ic_x),
+                contentDescription = "close banner",
+                tint = gray200,
+                modifier = Modifier.clickable { onBannerClose() }
+            )
+
+            HorizontalSpacer(width = 8.dp)
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun BannerPreview() {
+    Banner(
+        title = "Title",
+        content = "Content",
+        onBannerClick = {},
+        onBannerClose = {},
+        modifier = Modifier.padding(horizontal = 18.dp),
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/compose/components/Banner.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/compose/components/Banner.kt
@@ -25,6 +25,7 @@ import com.sopt.smeem.presentation.compose.theme.gray100
 import com.sopt.smeem.presentation.compose.theme.gray200
 import com.sopt.smeem.util.HorizontalSpacer
 import com.sopt.smeem.util.VerticalSpacer
+import com.sopt.smeem.util.noRippleClickable
 
 @Composable
 fun Banner(
@@ -70,7 +71,7 @@ fun Banner(
                 painter = painterResource(id = R.drawable.ic_x),
                 contentDescription = "close banner",
                 tint = gray200,
-                modifier = Modifier.clickable { onBannerClose() }
+                modifier = Modifier.noRippleClickable { onBannerClose() }
             )
 
             HorizontalSpacer(width = 8.dp)

--- a/app/src/main/java/com/sopt/smeem/presentation/home/ConfigInfo.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/ConfigInfo.kt
@@ -1,0 +1,10 @@
+package com.sopt.smeem.presentation.home
+
+data class ConfigInfo(
+    val bannerVersion: Int = 0,
+    val bannerTitle: String = "",
+    val bannerContent: String = "",
+    val isBannerEnabled: Boolean = false,
+    val isExternalEvent: Boolean = false,
+    val bannerEventPath: String = "",
+)

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -242,13 +242,15 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.background,
                         ) {
-                            Banner(
-                                title = configInfo.bannerTitle,
-                                content = configInfo.bannerContent,
-                                onBannerClick = { handleBannerClickEvent(configInfo) },
-                                onBannerClose = { /*TODO*/ },
-                                modifier = Modifier.padding(horizontal = 18.dp),
-                            )
+                            if (configInfo.isBannerEnabled) {
+                                Banner(
+                                    title = configInfo.bannerTitle,
+                                    content = configInfo.bannerContent,
+                                    onBannerClick = { handleBannerClickEvent(configInfo) },
+                                    onBannerClose = { /*TODO*/ },
+                                    modifier = Modifier.padding(horizontal = 18.dp),
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -3,7 +3,6 @@ package com.sopt.smeem.presentation.home
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
@@ -37,6 +36,8 @@ import com.sopt.smeem.presentation.home.calendar.SmeemCalendar
 import com.sopt.smeem.presentation.home.calendar.core.CalendarState
 import com.sopt.smeem.presentation.home.calendar.core.Period
 import com.sopt.smeem.presentation.mypage.MyPageActivity
+import com.sopt.smeem.presentation.write.foreign.ForeignWriteActivity
+import com.sopt.smeem.presentation.write.natiive.NativeWriteStep1Activity
 import com.sopt.smeem.util.DateUtil
 import com.sopt.smeem.util.getWeekStartDate
 import com.sopt.smeem.util.setComposeContent
@@ -243,7 +244,6 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 }.collect { (configInfo, isVisible) ->
                     setComposeContent(bannerView) {
                         SmeemTheme {
-                            Log.e("HomeActivity", "observeBannerState: isVisible = $isVisible")
                             if (isVisible) {
                                 Surface(
                                     modifier = Modifier.fillMaxWidth(),
@@ -272,13 +272,31 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         }
     }
 
+    /**
+     * 배너 클릭 이벤트 처리
+     * 외부 이벤트일 시 크롬 탭으로 URL 열기
+     * 내부 이벤트일 시 내부 화면으로 이동
+     */
     private fun handleBannerClickEvent(configInfo: ConfigInfo) {
         if (configInfo.isExternalEvent) {
             CustomTabsIntent.Builder().build().run {
                 launchUrl(this@HomeActivity, Uri.parse(configInfo.bannerEventPath))
             }
         } else {
-            // 내부 이벤트 처리
+            when (configInfo.bannerEventPath) {
+                // 한국어 일기 작성
+                "native_write_diary" -> {
+                    startActivity(Intent(this, NativeWriteStep1Activity::class.java))
+                }
+                // 영어 일기 작성
+                "foreign_write_diary" -> {
+                    startActivity(Intent(this, ForeignWriteActivity::class.java))
+                }
+                // 마이페이지 - 성과 요약
+                "my_page" -> {
+                    startActivity(Intent(this, MyPageActivity::class.java))
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -1,10 +1,12 @@
 package com.sopt.smeem.presentation.home
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -243,7 +245,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                             Banner(
                                 title = configInfo.bannerTitle,
                                 content = configInfo.bannerContent,
-                                onBannerClick = { /*TODO*/ },
+                                onBannerClick = { handleBannerClickEvent(configInfo) },
                                 onBannerClose = { /*TODO*/ },
                                 modifier = Modifier.padding(horizontal = 18.dp),
                             )
@@ -251,6 +253,18 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                     }
                 }
             }
+        }
+    }
+
+    private fun handleBannerClickEvent(configInfo: ConfigInfo) {
+        if (configInfo.isExternalEvent) {
+            Timber.e("외부 이벤트 처리")
+            CustomTabsIntent.Builder().build().run {
+                launchUrl(this@HomeActivity, Uri.parse(configInfo.bannerEventPath))
+            }
+        } else {
+            Timber.e("내부 이벤트 처리")
+            // 내부 이벤트 처리
         }
     }
 

--- a/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/home/HomeActivity.kt
@@ -3,6 +3,7 @@ package com.sopt.smeem.presentation.home
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
@@ -176,7 +177,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 if (isTodaySelected && !isTodayDiaryWritten) {
                     View.VISIBLE
                 } else {
-                    View.INVISIBLE
+                    View.GONE
                 }
         }
     }
@@ -242,6 +243,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                 }.collect { (configInfo, isVisible) ->
                     setComposeContent(bannerView) {
                         SmeemTheme {
+                            Log.e("HomeActivity", "observeBannerState: isVisible = $isVisible")
                             if (isVisible) {
                                 Surface(
                                     modifier = Modifier.fillMaxWidth(),
@@ -256,7 +258,11 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
                                         onBannerClose = {
                                             homeViewModel.closeBanner()
                                         },
-                                        modifier = Modifier.padding(horizontal = 18.dp),
+                                        modifier =
+                                            Modifier.padding(
+                                                horizontal = 18.dp,
+                                                vertical = 12.dp,
+                                            ),
                                     )
                                 }
                             }
@@ -268,12 +274,10 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
 
     private fun handleBannerClickEvent(configInfo: ConfigInfo) {
         if (configInfo.isExternalEvent) {
-            Timber.e("외부 이벤트 처리")
             CustomTabsIntent.Builder().build().run {
                 launchUrl(this@HomeActivity, Uri.parse(configInfo.bannerEventPath))
             }
         } else {
-            Timber.e("내부 이벤트 처리")
             // 내부 이벤트 처리
         }
     }

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/components/SendReviewCard.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/components/SendReviewCard.kt
@@ -1,0 +1,27 @@
+package com.sopt.smeem.presentation.mypage.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SendReviewCard(onEditClick: () -> Unit) {
+    SmeemContents(title = "의견 보내기") {
+        SmeemCard(
+            text = "스밈에 대한 의견을 남겨주세요 :)",
+        ) {
+            EditButton(
+                text = "바로가기",
+            ) {
+                onEditClick()
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun SendReviewCardPreview() {
+    SendReviewCard(
+        onEditClick = {},
+    )
+}

--- a/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/smeem/presentation/mypage/setting/SettingScreen.kt
@@ -1,10 +1,15 @@
 package com.sopt.smeem.presentation.mypage.setting
 
+import android.net.Uri
 import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,8 +27,10 @@ import com.sopt.smeem.domain.model.Day
 import com.sopt.smeem.domain.model.TrainingTime
 import com.sopt.smeem.presentation.compose.components.LoadingScreen
 import com.sopt.smeem.presentation.compose.components.SmeemAlarmCard
+import com.sopt.smeem.presentation.compose.theme.white
 import com.sopt.smeem.presentation.mypage.components.ChangeMyPlanCard
 import com.sopt.smeem.presentation.mypage.components.ChangeNicknameCard
+import com.sopt.smeem.presentation.mypage.components.SendReviewCard
 import com.sopt.smeem.presentation.mypage.components.StudyNotificationCard
 import com.sopt.smeem.presentation.mypage.components.TargetLanguageCard
 import com.sopt.smeem.presentation.mypage.navigation.SettingNavGraph
@@ -37,7 +44,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun SettingScreen(
     navController: NavController,
     viewModel: SettingViewModel = hiltViewModel(),
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val state by viewModel.collectAsState()
     val context = LocalContext.current
@@ -58,19 +65,26 @@ fun SettingScreen(
             val username = response.username
             val myPlan = response.trainingPlan?.content
             // val targetLanguage = response.targetLang TODO : 언어 추가시 주석 해제
-            val selectedTrainingTime = if (response.trainingTime!!.isSet()) {
-                response.trainingTime
-            } else {
-                TrainingTime(
-                    setOf(Day.MON, Day.TUE, Day.WED, Day.THU, Day.FRI),
-                    22,
-                    0
-                )
-            }
+            val selectedTrainingTime =
+                if (response.trainingTime!!.isSet()) {
+                    response.trainingTime
+                } else {
+                    TrainingTime(
+                        setOf(Day.MON, Day.TUE, Day.WED, Day.THU, Day.FRI),
+                        22,
+                        0,
+                    )
+                }
             var isSwitchChecked by rememberSaveable { mutableStateOf(response.hasPushAlarm) }
 
             Column(
-                modifier = modifier.fillMaxSize(),
+                modifier =
+                    modifier
+                        .fillMaxSize()
+                        .background(white)
+                        .verticalScroll(
+                            rememberScrollState(),
+                        ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 VerticalSpacer(height = 50.dp)
@@ -80,10 +94,10 @@ fun SettingScreen(
                     onEditClick = {
                         navController.navigate(
                             SettingNavGraph.ChangeNickname.createRoute(
-                                username
-                            )
+                                username,
+                            ),
                         )
-                    }
+                    },
                 )
 
                 VerticalSpacer(height = 28.dp)
@@ -93,7 +107,8 @@ fun SettingScreen(
                     myPlan = myPlan,
                     onEditClick = {
                         navController.navigate(SettingNavGraph.EditTrainingPlan.route)
-                    })
+                    },
+                )
 
                 VerticalSpacer(height = 28.dp)
 
@@ -110,17 +125,17 @@ fun SettingScreen(
                                 hasAlarm = true,
                                 onError = { t ->
                                     Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
-                                }
+                                },
                             )
                         } else {
                             viewModel.changePushAlarm(
                                 hasAlarm = false,
                                 onError = { t ->
                                     Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
-                                }
+                                },
                             )
                         }
-                    }
+                    },
                 )
 
                 VerticalSpacer(height = 10.dp)
@@ -134,15 +149,28 @@ fun SettingScreen(
                         if (isSwitchChecked) {
                             navController.currentBackStackEntry?.savedStateHandle?.set(
                                 "trainingTime",
-                                selectedTrainingTime
+                                selectedTrainingTime,
                             )
 
                             navController.navigate(
-                                SettingNavGraph.EditTrainingTime.route
+                                SettingNavGraph.EditTrainingTime.route,
                             )
                         }
-                    }
+                    },
                 )
+
+                VerticalSpacer(height = 56.dp)
+
+                SendReviewCard {
+                    CustomTabsIntent.Builder().build().run {
+                        launchUrl(
+                            context,
+                            Uri.parse("https://walla.my/survey/2SAyT8aWPKjqaL4cZ5vm"),
+                        )
+                    }
+                }
+
+                VerticalSpacer(height = 84.dp)
             }
         }
 
@@ -166,6 +194,6 @@ fun SettingScreenPreview() {
     SettingScreen(
         navController = rememberNavController(),
         viewModel = hiltViewModel(),
-        modifier = Modifier
+        modifier = Modifier,
     )
 }

--- a/app/src/main/java/com/sopt/smeem/util/ComposeContentUtil.kt
+++ b/app/src/main/java/com/sopt/smeem/util/ComposeContentUtil.kt
@@ -1,0 +1,15 @@
+package com.sopt.smeem.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+
+fun setComposeContent(
+    composeView: ComposeView,
+    content: @Composable () -> Unit,
+) {
+    composeView.apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent(content)
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -130,6 +130,15 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_banner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="12dp"
+            app:layout_constraintBottom_toTopOf="@id/btn_write_diary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
         <Button
             android:id="@+id/btn_write_diary"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -134,7 +134,6 @@
             android:id="@+id/compose_banner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="12dp"
             app:layout_constraintBottom_toTopOf="@id/btn_write_diary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
- closed #326 

## *⛳️ Work Description*
- Firebase remote config 연결
- 배너 버전과 배너를 지웠는지 유무를 DataStore에 저장 (배너를 한 번 닫으면 다시 안띄우기 위해)
- 최신 배너일시 배너 삭제 유무와 상관 없이 배너를 보여줌
- 외부 이벤트인지 내부 이벤트인지에 따라 다른 곳으로 Intent합니다.
- 배너 UI 구현 및 ComposeView로 HomeActivity에 Binding 
- LocalRepositiory에 Int, Boolean get set 함수 작성
- 설정뷰에 의견 보내기 카드 구현 후 반영했습니다. 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
### 배너 UI 구현 
> 일기 작성 유무에 따라 위치를 조정했습니다, 또 배너 클릭시 왈라로 링크 보냅니다

https://github.com/Team-Smeme/smeem-aos/assets/98825364/eacffa39-3132-47d5-b5e1-5cd96f9a074d


### 배너 업데이트 시 배너 닫았던 기록과 상관 없이 보여줌
https://github.com/Team-Smeme/smeem-aos/assets/98825364/7870c409-e285-4174-ae6f-185735404639

### 마이페이지 - 설정 뷰에 의견 보내기 카드 구현

https://github.com/Team-Smeme/smeem-aos/assets/98825364/17235881-2180-4264-94ee-6a416c8db314



## To Reviewer
- 내부 이벤트 해당 페이지가 정해지면 추가하고 push 하겠습니다~
